### PR TITLE
Allow overriding config.h and fix compiler issues.

### DIFF
--- a/gtkwave3-gtk3/src/helpers/fst/fastlz.c
+++ b/gtkwave3-gtk3/src/helpers/fst/fastlz.c
@@ -418,7 +418,9 @@ static FASTLZ_INLINE int FASTLZ_DECOMPRESSOR(const void* input, int length, void
   const flzuint8* ip = (const flzuint8*) input;
   const flzuint8* ip_limit  = ip + length;
   flzuint8* op = (flzuint8*) output;
+#ifdef FASTLZ_SAFE
   flzuint8* op_limit = op + maxout;
+#endif
   flzuint32 ctrl = (*ip++) & 31;
   int loop = 1;
 

--- a/gtkwave3-gtk3/src/helpers/fst/fstapi.c
+++ b/gtkwave3-gtk3/src/helpers/fst/fstapi.c
@@ -37,7 +37,10 @@
  *
  */
 
-#include <config.h>
+#ifndef FST_CONFIG_INCLUDE
+# define FST_CONFIG_INCLUDE <config.h>
+#endif
+#include FST_CONFIG_INCLUDE
 
 #include "fstapi.h"
 #include "fastlz.h"

--- a/gtkwave3-gtk3/src/wavealloca.h
+++ b/gtkwave3-gtk3/src/wavealloca.h
@@ -33,6 +33,9 @@
 #else
 #include <malloc.h>
 #endif
+#elif defined(_MSC_VER)
+#include <malloc.h>
+#define alloca _alloca
 #endif
 #define wave_alloca alloca
 #endif

--- a/gtkwave3/src/helpers/fst/fastlz.c
+++ b/gtkwave3/src/helpers/fst/fastlz.c
@@ -418,7 +418,9 @@ static FASTLZ_INLINE int FASTLZ_DECOMPRESSOR(const void* input, int length, void
   const flzuint8* ip = (const flzuint8*) input;
   const flzuint8* ip_limit  = ip + length;
   flzuint8* op = (flzuint8*) output;
+#ifdef FASTLZ_SAFE
   flzuint8* op_limit = op + maxout;
+#endif
   flzuint32 ctrl = (*ip++) & 31;
   int loop = 1;
 

--- a/gtkwave3/src/helpers/fst/fstapi.c
+++ b/gtkwave3/src/helpers/fst/fstapi.c
@@ -37,7 +37,10 @@
  *
  */
 
-#include <config.h>
+#ifndef FST_CONFIG_INCLUDE
+# define FST_CONFIG_INCLUDE <config.h>
+#endif
+#include FST_CONFIG_INCLUDE
 
 #include "fstapi.h"
 #include "fastlz.h"


### PR DESCRIPTION
This fixes:
- Inconsistency in wavealloc.h between versions breaking MSC.
- GCC unused variable warning
- Adds ifdef so Verilator can have identical files

Thanks for the git repo, I'm privileged to send your first "pull request"!  Let me know if there's any issues.  If it looks good you can just accept the pull request (I suggest the "squash" option) and github will do the rest. Otherwise:  https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/merging-a-pull-request
