### PR TITLE
Use __attribute__((__common__)) in wave_rpc_id declaration

### DIFF
--- a/gtkwave3-gtk3/src/gconf.h
+++ b/gtkwave3-gtk3/src/gconf.h
@@ -26,7 +26,7 @@
 /*                      12345678901234567 */
 #define WAVE_GCONF_DIR_LEN (17)
 
-extern int wave_rpc_id;
+extern int wave_rpc_id __attribute__((__common__));
 
 void wave_gconf_init(int argc, char **argv);
 gboolean wave_gconf_client_set_string(const gchar *key, const gchar *val);

--- a/gtkwave3/src/gconf.h
+++ b/gtkwave3/src/gconf.h
@@ -26,7 +26,7 @@
 /*                      12345678901234567 */
 #define WAVE_GCONF_DIR_LEN (17)
 
-extern int wave_rpc_id;
+extern int wave_rpc_id __attribute__((__common__));
 
 void wave_gconf_init(int argc, char **argv);
 gboolean wave_gconf_client_set_string(const gchar *key, const gchar *val);


### PR DESCRIPTION
Fixes !15