### PR TITLE
ghw: resync ghwlib and adjust ghw.c

### DIFF
--- a/gtkwave3-gtk3/ChangeLog
+++ b/gtkwave3-gtk3/ChangeLog
@@ -1800,3 +1800,4 @@
 		Examine	env var	$HOME for home dir on geteuid failure.
 		Fix blurring on use_fat_lines rc variable usage.
 3.3.106	31jul20	Fix Shift-Up/Down highlight to traverse inside groups.
+		Resync ghwlib to handled unbounded arrays.

--- a/gtkwave3-gtk3/src/ghw.c
+++ b/gtkwave3-gtk3/src/ghw.c
@@ -450,7 +450,8 @@ build_hierarchy_array (struct ghw_handler *h, union ghw_type *arr, int dim,
 		       const char *pfx, struct tree **res, unsigned int **sig)
 {
   union ghw_type *idx;
-  struct ghw_type_array *base = arr->sa.base;
+  struct ghw_type_array *base =
+    (struct ghw_type_array *) ghw_get_base_type (arr->sa.base);
   char *name = NULL;
 
   if ((unsigned int)dim == base->nbr_dim)
@@ -459,7 +460,7 @@ build_hierarchy_array (struct ghw_handler *h, union ghw_type *arr, int dim,
       sprintf (GLOBALS->asbuf, "%s]", pfx);
       name = strdup_2(GLOBALS->asbuf);
 
-      t = build_hierarchy_type (h, base->el, name, sig);
+      t = build_hierarchy_type (h, arr->sa.el, name, sig);
 
       if (*res != NULL)
 	(*res)->next = t;

--- a/gtkwave3-gtk3/src/ghwlib.c
+++ b/gtkwave3-gtk3/src/ghwlib.c
@@ -439,11 +439,14 @@ ghw_get_base_type (union ghw_type *t)
     case ghdl_rtik_type_f64:
     case ghdl_rtik_type_p32:
     case ghdl_rtik_type_p64:
+    case ghdl_rtik_type_array:
       return t;
     case ghdl_rtik_subtype_scalar:
       return t->ss.base;
     case ghdl_rtik_subtype_array:
-      return (union ghw_type*)(t->sa.base);
+      return t->sa.base;
+    case ghdl_rtik_subtype_unbounded_array:
+      return t->sua.base;
     default:
       fprintf (stderr, "ghw_get_base_type: cannot handle type %d\n", t->kind);
       abort ();
@@ -474,6 +477,9 @@ get_nbr_elements (union ghw_type *t)
       return t->rec.nbr_scalars;
     case ghdl_rtik_subtype_record:
       return t->sr.nbr_scalars;
+    case ghdl_rtik_subtype_unbounded_record:
+    case ghdl_rtik_subtype_unbounded_array:
+      return -1;
     default:
       fprintf (stderr, "get_nbr_elements: unhandled type %d\n", t->kind);
       abort ();
@@ -515,27 +521,45 @@ ghw_get_range_length (union ghw_range *rng)
   return (res <= 0) ? 0 : res;
 }
 
+static union ghw_type *
+ghw_read_type_bounds (struct ghw_handler *h, union ghw_type *base);
+
 /* Create an array subtype using BASE and ranges read from H.  */
 
 struct ghw_subtype_array *
-ghw_read_array_subtype (struct ghw_handler *h, struct ghw_type_array *base)
+ghw_read_array_subtype (struct ghw_handler *h, union ghw_type *base)
 {
+  struct ghw_type_array *arr =
+    (struct ghw_type_array *)ghw_get_base_type (base);
   struct ghw_subtype_array *sa;
   unsigned j;
   int nbr_scalars;
+  int nbr_els;
 
   sa = malloc (sizeof (struct ghw_subtype_array));
   sa->kind = ghdl_rtik_subtype_array;
   sa->name = NULL;
   sa->base = base;
-  nbr_scalars = get_nbr_elements (base->el);
-  sa->rngs = malloc (base->nbr_dim * sizeof (union ghw_range *));
-  for (j = 0; j < base->nbr_dim; j++)
+  nbr_els = get_nbr_elements (arr->el);
+  nbr_scalars = 1;
+  sa->rngs = malloc (arr->nbr_dim * sizeof (union ghw_range *));
+  for (j = 0; j < arr->nbr_dim; j++)
     {
       sa->rngs[j] = ghw_read_range (h);
       nbr_scalars *= ghw_get_range_length (sa->rngs[j]);
     }
-  sa->nbr_scalars = nbr_scalars;
+  if (nbr_els >= 0)
+    {
+      /* Element type is bounded.  */
+      sa->el = arr->el;
+    }
+  else
+    {
+      /* Read bounds for the elements.  */
+      sa->el = ghw_read_type_bounds(h, arr->el);
+      nbr_els = get_nbr_elements (sa->el);
+    }
+    sa->nbr_scalars = nbr_scalars * nbr_els;
   return sa;
 }
 
@@ -575,22 +599,7 @@ ghw_read_record_subtype (struct ghw_handler *h, struct ghw_type_record *base)
 	    }
 	  else
 	    {
-	      switch (btype->kind)
-		{
-		case ghdl_rtik_type_array:
-		  sr->els[j].type = (union ghw_type *)
-		    ghw_read_array_subtype (h, &btype->ar);
-		  break;
-		case ghdl_rtik_type_record:
-		  sr->els[j].type = (union ghw_type *)
-		    ghw_read_record_subtype (h, &btype->rec);
-		  break;
-		default:
-		  fprintf
-		    (stderr, "ghw_read_record_subtype: unhandled kind %d\n",
-		     btype->kind);
-		  return NULL;
-		}
+              sr->els[j].type = ghw_read_type_bounds(h, btype);
 	      el_nbr_scalars = get_nbr_elements (sr->els[j].type);
 	    }
 	  nbr_scalars += el_nbr_scalars;
@@ -598,6 +607,28 @@ ghw_read_record_subtype (struct ghw_handler *h, struct ghw_type_record *base)
       sr->nbr_scalars = nbr_scalars;
     }
   return sr;
+}
+
+/* Read bounds for BASE and create a subtype.  */
+
+static union ghw_type *
+ghw_read_type_bounds (struct ghw_handler *h, union ghw_type *base)
+{
+  switch (base->kind)
+    {
+    case ghdl_rtik_type_array:
+    case ghdl_rtik_subtype_unbounded_array:
+      return (union ghw_type *)ghw_read_array_subtype (h, base);
+      break;
+    case ghdl_rtik_type_record:
+    case ghdl_rtik_subtype_unbounded_record:
+      return (union ghw_type *)ghw_read_record_subtype (h, &base->rec);
+      break;
+    default:
+      fprintf (stderr, "ghw_read_type_bounds: unhandled kind %d\n",
+               base->kind);
+      return NULL;
+    }
 }
 
 int
@@ -622,7 +653,8 @@ ghw_read_type (struct ghw_handler *h)
       t = fgetc (h->stream);
       if (t == EOF)
 	return -1;
-      /* printf ("type[%d]= %d\n", i, t); */
+      if (h->flag_verbose > 1)
+        printf ("type[%d]= %d\n", i, t);
       switch (t)
 	{
 	case ghdl_rtik_type_b2:
@@ -734,7 +766,8 @@ ghw_read_type (struct ghw_handler *h)
 	    for (j = 0; j < arr->nbr_dim; j++)
 	      arr->dims[j] = ghw_read_typeid (h);
 	    if (h->flag_verbose > 1)
-	      printf ("array: %s\n", arr->name);
+	      printf ("array: %s (ndim=%u) of %s\n",
+                      arr->name, arr->nbr_dim, arr->el->common.name);
 	    h->types[i] = (union ghw_type *)arr;
 	    break;
 	  err_array:
@@ -746,10 +779,10 @@ ghw_read_type (struct ghw_handler *h)
 	  {
 	    struct ghw_subtype_array *sa;
 	    const char *name;
-	    struct ghw_type_array *base;
+	    union ghw_type *base;
 
 	    name = ghw_read_strid (h);
-	    base = (struct ghw_type_array *)ghw_read_typeid (h);
+	    base = ghw_read_typeid (h);
 
 	    sa = ghw_read_array_subtype (h, base);
 	    sa->name = name;
@@ -757,6 +790,19 @@ ghw_read_type (struct ghw_handler *h)
 	    if (h->flag_verbose > 1)
 	      printf ("subtype array: %s (nbr_scalars=%d)\n",
 		      sa->name, sa->nbr_scalars);
+	  }
+	  break;
+	case ghdl_rtik_subtype_unbounded_array:
+	  {
+	    struct ghw_subtype_unbounded_array *sua;
+
+            sua = malloc (sizeof (struct ghw_subtype_unbounded_array));
+            sua->kind = t;
+	    sua->name = ghw_read_strid (h);
+	    sua->base = ghw_read_typeid (h);
+	    h->types[i] = (union ghw_type *)sua;
+	    if (h->flag_verbose > 1)
+	      printf ("subtype unbounded array: %s\n", sua->name);
 	  }
 	  break;
 	case ghdl_rtik_type_record:
@@ -897,10 +943,10 @@ ghw_read_signal (struct ghw_handler *h, unsigned int *sigs, union ghw_type *t)
 	int len;
 
 	len = t->sa.nbr_scalars;
-	stride = get_nbr_elements (t->sa.base->el);
+	stride = get_nbr_elements (t->sa.el);
 
 	for (i = 0; i < len; i += stride)
-	  if (ghw_read_signal (h, &sigs[i], t->sa.base->el) < 0)
+	  if (ghw_read_signal (h, &sigs[i], t->sa.el) < 0)
 	    return -1;
       }
       return 0;
@@ -1090,6 +1136,7 @@ ghw_read_hie (struct ghw_handler *h)
 	  /* Should not be here.  */
 	  abort ();
 	case ghw_hie_process:
+	  el->u.blk.child = NULL;
 	  break;
 	case ghw_hie_block:
 	case ghw_hie_generate_if:
@@ -1313,8 +1360,8 @@ ghw_disp_hie (struct ghw_handler *h, struct ghw_hie *top)
 	    ghw_disp_subtype_indication (h, hie->u.sig.type);
 	    printf (":");
 	    k = 0;
-	    assert (sigs[0] != GHW_NO_SIG);
-	    while (1)
+	    /* There can be 0-length signals.  */
+	    while (sigs[k] != GHW_NO_SIG)
 	      {
 		/* First signal of the range.  */
 		printf (" #%u", sigs[k]);
@@ -1324,9 +1371,6 @@ ghw_disp_hie (struct ghw_handler *h, struct ghw_hie *top)
 		if (num > 1)
 		  printf ("-#%u", sigs[k + num - 1]);
 		k += num;
-		/* End of signals ? */
-		if (sigs[k] == GHW_NO_SIG)
-		  break;
 	      }
 	    n = hie->brother;
 	  }
@@ -1977,13 +2021,15 @@ static void
 ghw_disp_array_subtype_bounds (struct ghw_subtype_array *a)
 {
   unsigned i;
+  struct ghw_type_array *base =
+    (struct ghw_type_array *)ghw_get_base_type (a->base);
 
   printf (" (");
-  for (i = 0; i < a->base->nbr_dim; i++)
+  for (i = 0; i < base->nbr_dim; i++)
     {
       if (i != 0)
 	printf (", ");
-      ghw_disp_range (a->base->dims[i], a->rngs[i]);
+      ghw_disp_range (base->dims[i], a->rngs[i]);
     }
   printf (")");
 }
@@ -2051,6 +2097,13 @@ ghw_disp_subtype_definition (struct ghw_handler *h, union ghw_type *t)
 
 	ghw_disp_typename (h, (union ghw_type *)sr->base);
 	ghw_disp_record_subtype_bounds (sr);
+      }
+      break;
+    case ghdl_rtik_subtype_unbounded_array:
+      {
+	struct ghw_subtype_unbounded_record *sur = &t->sur;
+
+	ghw_disp_typename (h, (union ghw_type *)sur->base);
       }
       break;
     default:
@@ -2160,6 +2213,7 @@ ghw_disp_type (struct ghw_handler *h, union ghw_type *t)
     case ghdl_rtik_subtype_array:
     case ghdl_rtik_subtype_scalar:
     case ghdl_rtik_subtype_record:
+    case ghdl_rtik_subtype_unbounded_array:
       {
 	struct ghw_type_common *c = &t->common;
 	printf ("subtype %s is ", c->name);

--- a/gtkwave3-gtk3/src/ghwlib.h
+++ b/gtkwave3-gtk3/src/ghwlib.h
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+/* To be libraries friendly.  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -82,16 +83,19 @@ enum ghdl_rtik {
   ghdl_rtik_type_file,
   ghdl_rtik_subtype_scalar,
   ghdl_rtik_subtype_array,	/* 35 */
-  ghdl_rtik_subtype_array_ptr,             /* Obsolete.  */
-  ghdl_rtik_subtype_unconstrained_array,   /* Obsolete.  */
+  ghdl_rtik_subtype_array_ptr,  /* Obsolete.  */
+  ghdl_rtik_subtype_unbounded_array,
   ghdl_rtik_subtype_record,
-  ghdl_rtik_subtype_access,
+  ghdl_rtik_subtype_unbounded_record,
+#if 0
+  ghdl_rtik_subtype_access,     /* 40 */
   ghdl_rtik_type_protected,
   ghdl_rtik_element,
   ghdl_rtik_unit,
   ghdl_rtik_attribute_transaction,
   ghdl_rtik_attribute_quiet,
   ghdl_rtik_attribute_stable,
+#endif
   ghdl_rtik_error
 };
 
@@ -202,14 +206,23 @@ struct ghw_type_array
   union ghw_type **dims;
 };
 
+struct ghw_subtype_unbounded_array
+{
+  enum ghdl_rtik kind;
+  const char *name;
+
+  union ghw_type *base;
+};
+
 struct ghw_subtype_array
 {
   enum ghdl_rtik kind;
   const char *name;
 
-  struct ghw_type_array *base;
+  union ghw_type *base;
   int nbr_scalars;
   union ghw_range **rngs;
+  union ghw_type *el;
 };
 
 struct ghw_subtype_scalar
@@ -247,6 +260,14 @@ struct ghw_subtype_record
   struct ghw_record_element *els;
 };
 
+struct ghw_subtype_unbounded_record
+{
+  enum ghdl_rtik kind;
+  const char *name;
+
+  struct ghw_type_record *base;
+};
+
 union ghw_type
 {
   enum ghdl_rtik kind;
@@ -255,10 +276,12 @@ union ghw_type
   struct ghw_type_scalar sc;
   struct ghw_type_physical ph;
   struct ghw_subtype_scalar ss;
-  struct ghw_subtype_array sa;
-  struct ghw_subtype_record sr;
   struct ghw_type_array ar;
   struct ghw_type_record rec;
+  struct ghw_subtype_array sa;
+  struct ghw_subtype_unbounded_array sua;
+  struct ghw_subtype_record sr;
+  struct ghw_subtype_unbounded_record sur;
 };
 
 union ghw_val
@@ -414,6 +437,8 @@ enum ghw_res {
   ghw_res_other = 3
 };
 
+enum ghw_res ghw_read_sm_hdr (struct ghw_handler *h, int *list);
+
 int ghw_read_sm (struct ghw_handler *h, enum ghw_sm_type *sm);
 
 int ghw_read_dump (struct ghw_handler *h);
@@ -439,7 +464,4 @@ void ghw_disp_range (union ghw_type *type, union ghw_range *rng);
 void ghw_disp_type (struct ghw_handler *h, union ghw_type *t);
 
 void ghw_disp_types (struct ghw_handler *h);
-
-enum ghw_res ghw_read_sm_hdr (struct ghw_handler *h, int *list);
-
 #endif /* _GHWLIB_H_ */

--- a/gtkwave3/ChangeLog
+++ b/gtkwave3/ChangeLog
@@ -1738,3 +1738,4 @@
 		Examine env var $HOME for home dir on geteuid failure.
 3.3.106	06jul20	Fix for GDK_KEY_* definitions missing in older GDK versions.
 		Fix Shift-Up/Down highlight to traverse inside groups.
+		Resync ghwlib to handled unbounded arrays.

--- a/gtkwave3/src/ghw.c
+++ b/gtkwave3/src/ghw.c
@@ -450,7 +450,8 @@ build_hierarchy_array (struct ghw_handler *h, union ghw_type *arr, int dim,
 		       const char *pfx, struct tree **res, unsigned int **sig)
 {
   union ghw_type *idx;
-  struct ghw_type_array *base = arr->sa.base;
+  struct ghw_type_array *base =
+    (struct ghw_type_array *) ghw_get_base_type (arr->sa.base);
   char *name = NULL;
 
   if ((unsigned int)dim == base->nbr_dim)
@@ -459,7 +460,7 @@ build_hierarchy_array (struct ghw_handler *h, union ghw_type *arr, int dim,
       sprintf (GLOBALS->asbuf, "%s]", pfx);
       name = strdup_2(GLOBALS->asbuf);
 
-      t = build_hierarchy_type (h, base->el, name, sig);
+      t = build_hierarchy_type (h, arr->sa.el, name, sig);
 
       if (*res != NULL)
 	(*res)->next = t;

--- a/gtkwave3/src/ghwlib.c
+++ b/gtkwave3/src/ghwlib.c
@@ -439,11 +439,14 @@ ghw_get_base_type (union ghw_type *t)
     case ghdl_rtik_type_f64:
     case ghdl_rtik_type_p32:
     case ghdl_rtik_type_p64:
+    case ghdl_rtik_type_array:
       return t;
     case ghdl_rtik_subtype_scalar:
       return t->ss.base;
     case ghdl_rtik_subtype_array:
-      return (union ghw_type*)(t->sa.base);
+      return t->sa.base;
+    case ghdl_rtik_subtype_unbounded_array:
+      return t->sua.base;
     default:
       fprintf (stderr, "ghw_get_base_type: cannot handle type %d\n", t->kind);
       abort ();
@@ -474,6 +477,9 @@ get_nbr_elements (union ghw_type *t)
       return t->rec.nbr_scalars;
     case ghdl_rtik_subtype_record:
       return t->sr.nbr_scalars;
+    case ghdl_rtik_subtype_unbounded_record:
+    case ghdl_rtik_subtype_unbounded_array:
+      return -1;
     default:
       fprintf (stderr, "get_nbr_elements: unhandled type %d\n", t->kind);
       abort ();
@@ -515,27 +521,45 @@ ghw_get_range_length (union ghw_range *rng)
   return (res <= 0) ? 0 : res;
 }
 
+static union ghw_type *
+ghw_read_type_bounds (struct ghw_handler *h, union ghw_type *base);
+
 /* Create an array subtype using BASE and ranges read from H.  */
 
 struct ghw_subtype_array *
-ghw_read_array_subtype (struct ghw_handler *h, struct ghw_type_array *base)
+ghw_read_array_subtype (struct ghw_handler *h, union ghw_type *base)
 {
+  struct ghw_type_array *arr =
+    (struct ghw_type_array *)ghw_get_base_type (base);
   struct ghw_subtype_array *sa;
   unsigned j;
   int nbr_scalars;
+  int nbr_els;
 
   sa = malloc (sizeof (struct ghw_subtype_array));
   sa->kind = ghdl_rtik_subtype_array;
   sa->name = NULL;
   sa->base = base;
-  nbr_scalars = get_nbr_elements (base->el);
-  sa->rngs = malloc (base->nbr_dim * sizeof (union ghw_range *));
-  for (j = 0; j < base->nbr_dim; j++)
+  nbr_els = get_nbr_elements (arr->el);
+  nbr_scalars = 1;
+  sa->rngs = malloc (arr->nbr_dim * sizeof (union ghw_range *));
+  for (j = 0; j < arr->nbr_dim; j++)
     {
       sa->rngs[j] = ghw_read_range (h);
       nbr_scalars *= ghw_get_range_length (sa->rngs[j]);
     }
-  sa->nbr_scalars = nbr_scalars;
+  if (nbr_els >= 0)
+    {
+      /* Element type is bounded.  */
+      sa->el = arr->el;
+    }
+  else
+    {
+      /* Read bounds for the elements.  */
+      sa->el = ghw_read_type_bounds(h, arr->el);
+      nbr_els = get_nbr_elements (sa->el);
+    }
+    sa->nbr_scalars = nbr_scalars * nbr_els;
   return sa;
 }
 
@@ -575,22 +599,7 @@ ghw_read_record_subtype (struct ghw_handler *h, struct ghw_type_record *base)
 	    }
 	  else
 	    {
-	      switch (btype->kind)
-		{
-		case ghdl_rtik_type_array:
-		  sr->els[j].type = (union ghw_type *)
-		    ghw_read_array_subtype (h, &btype->ar);
-		  break;
-		case ghdl_rtik_type_record:
-		  sr->els[j].type = (union ghw_type *)
-		    ghw_read_record_subtype (h, &btype->rec);
-		  break;
-		default:
-		  fprintf
-		    (stderr, "ghw_read_record_subtype: unhandled kind %d\n",
-		     btype->kind);
-		  return NULL;
-		}
+              sr->els[j].type = ghw_read_type_bounds(h, btype);
 	      el_nbr_scalars = get_nbr_elements (sr->els[j].type);
 	    }
 	  nbr_scalars += el_nbr_scalars;
@@ -598,6 +607,28 @@ ghw_read_record_subtype (struct ghw_handler *h, struct ghw_type_record *base)
       sr->nbr_scalars = nbr_scalars;
     }
   return sr;
+}
+
+/* Read bounds for BASE and create a subtype.  */
+
+static union ghw_type *
+ghw_read_type_bounds (struct ghw_handler *h, union ghw_type *base)
+{
+  switch (base->kind)
+    {
+    case ghdl_rtik_type_array:
+    case ghdl_rtik_subtype_unbounded_array:
+      return (union ghw_type *)ghw_read_array_subtype (h, base);
+      break;
+    case ghdl_rtik_type_record:
+    case ghdl_rtik_subtype_unbounded_record:
+      return (union ghw_type *)ghw_read_record_subtype (h, &base->rec);
+      break;
+    default:
+      fprintf (stderr, "ghw_read_type_bounds: unhandled kind %d\n",
+               base->kind);
+      return NULL;
+    }
 }
 
 int
@@ -622,7 +653,8 @@ ghw_read_type (struct ghw_handler *h)
       t = fgetc (h->stream);
       if (t == EOF)
 	return -1;
-      /* printf ("type[%d]= %d\n", i, t); */
+      if (h->flag_verbose > 1)
+        printf ("type[%d]= %d\n", i, t);
       switch (t)
 	{
 	case ghdl_rtik_type_b2:
@@ -734,7 +766,8 @@ ghw_read_type (struct ghw_handler *h)
 	    for (j = 0; j < arr->nbr_dim; j++)
 	      arr->dims[j] = ghw_read_typeid (h);
 	    if (h->flag_verbose > 1)
-	      printf ("array: %s\n", arr->name);
+	      printf ("array: %s (ndim=%u) of %s\n",
+                      arr->name, arr->nbr_dim, arr->el->common.name);
 	    h->types[i] = (union ghw_type *)arr;
 	    break;
 	  err_array:
@@ -746,10 +779,10 @@ ghw_read_type (struct ghw_handler *h)
 	  {
 	    struct ghw_subtype_array *sa;
 	    const char *name;
-	    struct ghw_type_array *base;
+	    union ghw_type *base;
 
 	    name = ghw_read_strid (h);
-	    base = (struct ghw_type_array *)ghw_read_typeid (h);
+	    base = ghw_read_typeid (h);
 
 	    sa = ghw_read_array_subtype (h, base);
 	    sa->name = name;
@@ -757,6 +790,19 @@ ghw_read_type (struct ghw_handler *h)
 	    if (h->flag_verbose > 1)
 	      printf ("subtype array: %s (nbr_scalars=%d)\n",
 		      sa->name, sa->nbr_scalars);
+	  }
+	  break;
+	case ghdl_rtik_subtype_unbounded_array:
+	  {
+	    struct ghw_subtype_unbounded_array *sua;
+
+            sua = malloc (sizeof (struct ghw_subtype_unbounded_array));
+            sua->kind = t;
+	    sua->name = ghw_read_strid (h);
+	    sua->base = ghw_read_typeid (h);
+	    h->types[i] = (union ghw_type *)sua;
+	    if (h->flag_verbose > 1)
+	      printf ("subtype unbounded array: %s\n", sua->name);
 	  }
 	  break;
 	case ghdl_rtik_type_record:
@@ -897,10 +943,10 @@ ghw_read_signal (struct ghw_handler *h, unsigned int *sigs, union ghw_type *t)
 	int len;
 
 	len = t->sa.nbr_scalars;
-	stride = get_nbr_elements (t->sa.base->el);
+	stride = get_nbr_elements (t->sa.el);
 
 	for (i = 0; i < len; i += stride)
-	  if (ghw_read_signal (h, &sigs[i], t->sa.base->el) < 0)
+	  if (ghw_read_signal (h, &sigs[i], t->sa.el) < 0)
 	    return -1;
       }
       return 0;
@@ -1090,6 +1136,7 @@ ghw_read_hie (struct ghw_handler *h)
 	  /* Should not be here.  */
 	  abort ();
 	case ghw_hie_process:
+	  el->u.blk.child = NULL;
 	  break;
 	case ghw_hie_block:
 	case ghw_hie_generate_if:
@@ -1313,8 +1360,8 @@ ghw_disp_hie (struct ghw_handler *h, struct ghw_hie *top)
 	    ghw_disp_subtype_indication (h, hie->u.sig.type);
 	    printf (":");
 	    k = 0;
-	    assert (sigs[0] != GHW_NO_SIG);
-	    while (1)
+	    /* There can be 0-length signals.  */
+	    while (sigs[k] != GHW_NO_SIG)
 	      {
 		/* First signal of the range.  */
 		printf (" #%u", sigs[k]);
@@ -1324,9 +1371,6 @@ ghw_disp_hie (struct ghw_handler *h, struct ghw_hie *top)
 		if (num > 1)
 		  printf ("-#%u", sigs[k + num - 1]);
 		k += num;
-		/* End of signals ? */
-		if (sigs[k] == GHW_NO_SIG)
-		  break;
 	      }
 	    n = hie->brother;
 	  }
@@ -1977,13 +2021,15 @@ static void
 ghw_disp_array_subtype_bounds (struct ghw_subtype_array *a)
 {
   unsigned i;
+  struct ghw_type_array *base =
+    (struct ghw_type_array *)ghw_get_base_type (a->base);
 
   printf (" (");
-  for (i = 0; i < a->base->nbr_dim; i++)
+  for (i = 0; i < base->nbr_dim; i++)
     {
       if (i != 0)
 	printf (", ");
-      ghw_disp_range (a->base->dims[i], a->rngs[i]);
+      ghw_disp_range (base->dims[i], a->rngs[i]);
     }
   printf (")");
 }
@@ -2051,6 +2097,13 @@ ghw_disp_subtype_definition (struct ghw_handler *h, union ghw_type *t)
 
 	ghw_disp_typename (h, (union ghw_type *)sr->base);
 	ghw_disp_record_subtype_bounds (sr);
+      }
+      break;
+    case ghdl_rtik_subtype_unbounded_array:
+      {
+	struct ghw_subtype_unbounded_record *sur = &t->sur;
+
+	ghw_disp_typename (h, (union ghw_type *)sur->base);
       }
       break;
     default:
@@ -2160,6 +2213,7 @@ ghw_disp_type (struct ghw_handler *h, union ghw_type *t)
     case ghdl_rtik_subtype_array:
     case ghdl_rtik_subtype_scalar:
     case ghdl_rtik_subtype_record:
+    case ghdl_rtik_subtype_unbounded_array:
       {
 	struct ghw_type_common *c = &t->common;
 	printf ("subtype %s is ", c->name);

--- a/gtkwave3/src/ghwlib.h
+++ b/gtkwave3/src/ghwlib.h
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+/* To be libraries friendly.  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -82,16 +83,19 @@ enum ghdl_rtik {
   ghdl_rtik_type_file,
   ghdl_rtik_subtype_scalar,
   ghdl_rtik_subtype_array,	/* 35 */
-  ghdl_rtik_subtype_array_ptr,             /* Obsolete.  */
-  ghdl_rtik_subtype_unconstrained_array,   /* Obsolete.  */
+  ghdl_rtik_subtype_array_ptr,  /* Obsolete.  */
+  ghdl_rtik_subtype_unbounded_array,
   ghdl_rtik_subtype_record,
-  ghdl_rtik_subtype_access,
+  ghdl_rtik_subtype_unbounded_record,
+#if 0
+  ghdl_rtik_subtype_access,     /* 40 */
   ghdl_rtik_type_protected,
   ghdl_rtik_element,
   ghdl_rtik_unit,
   ghdl_rtik_attribute_transaction,
   ghdl_rtik_attribute_quiet,
   ghdl_rtik_attribute_stable,
+#endif
   ghdl_rtik_error
 };
 
@@ -202,14 +206,23 @@ struct ghw_type_array
   union ghw_type **dims;
 };
 
+struct ghw_subtype_unbounded_array
+{
+  enum ghdl_rtik kind;
+  const char *name;
+
+  union ghw_type *base;
+};
+
 struct ghw_subtype_array
 {
   enum ghdl_rtik kind;
   const char *name;
 
-  struct ghw_type_array *base;
+  union ghw_type *base;
   int nbr_scalars;
   union ghw_range **rngs;
+  union ghw_type *el;
 };
 
 struct ghw_subtype_scalar
@@ -247,6 +260,14 @@ struct ghw_subtype_record
   struct ghw_record_element *els;
 };
 
+struct ghw_subtype_unbounded_record
+{
+  enum ghdl_rtik kind;
+  const char *name;
+
+  struct ghw_type_record *base;
+};
+
 union ghw_type
 {
   enum ghdl_rtik kind;
@@ -255,10 +276,12 @@ union ghw_type
   struct ghw_type_scalar sc;
   struct ghw_type_physical ph;
   struct ghw_subtype_scalar ss;
-  struct ghw_subtype_array sa;
-  struct ghw_subtype_record sr;
   struct ghw_type_array ar;
   struct ghw_type_record rec;
+  struct ghw_subtype_array sa;
+  struct ghw_subtype_unbounded_array sua;
+  struct ghw_subtype_record sr;
+  struct ghw_subtype_unbounded_record sur;
 };
 
 union ghw_val
@@ -414,6 +437,8 @@ enum ghw_res {
   ghw_res_other = 3
 };
 
+enum ghw_res ghw_read_sm_hdr (struct ghw_handler *h, int *list);
+
 int ghw_read_sm (struct ghw_handler *h, enum ghw_sm_type *sm);
 
 int ghw_read_dump (struct ghw_handler *h);
@@ -439,7 +464,4 @@ void ghw_disp_range (union ghw_type *type, union ghw_range *rng);
 void ghw_disp_type (struct ghw_handler *h, union ghw_type *t);
 
 void ghw_disp_types (struct ghw_handler *h);
-
-enum ghw_res ghw_read_sm_hdr (struct ghw_handler *h, int *list);
-
 #endif /* _GHWLIB_H_ */


### PR DESCRIPTION
To handle unbounded arrays and records.

The file format is backward compatible but new types have been added for vhdl 2008