### PR TITLE
Sync files in gtkwave3-gtk3 to gtkwave3

### DIFF
--- a/gtkwave3-gtk3/src/wavealloca.h
+++ b/gtkwave3-gtk3/src/wavealloca.h
@@ -35,6 +35,9 @@
 #else
 #include <malloc.h>
 #endif
+#elif defined(_MSC_VER)
+#include <malloc.h>
+#define alloca _alloca
 #endif
 #define wave_alloca alloca
 #endif


### PR DESCRIPTION
I found wavealloca.h in gtkwave3-gtk3 is not same as that in gtkwave3.
https://github.com/gtkwave/gtkwave/blob/f119b35816e605e753fc1a24ae121a3787615b26/gtkwave3/src/wavealloca.h#L38-L41
https://github.com/gtkwave/gtkwave/blob/f119b35816e605e753fc1a24ae121a3787615b26/gtkwave3-gtk3/src/wavealloca.h#L36-L40

I am not sure about the development policy of gtkwave3 and -gtk3, but I think it would be simpler if files not related gtk are same in both directories. (or perhaps make them symlink ?)

I found some more files that are different regarding  _MSC_VER ifdefs. If you prefer, I can push another commit to sync them.