### PR TITLE
ci: fix MSYS2 recipes, try 3 times

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,12 +34,20 @@ jobs:
     - uses: msys2/setup-msys2@v2
       with:
         update: true
-        install: base-devel git mingw-w64-${{ matrix.target.arch }}-toolchain
+        install: >
+          base-devel
+          git
+          mingw-w64-${{ matrix.target.arch }}-toolchain
         msystem: ${{ matrix.target.msys2 }}
 
     - name: Build package
       working-directory: MSYS2/gtk${{ matrix.gtk }}
-      run: makepkg-mingw --noconfirm -sCLfc
+      run: |
+        tries=0
+        # Try building three times due to the arbitrary 'Bad address' error
+        while [ $tries -lt 3 ]; do
+          makepkg-mingw --noconfirm --noprogressbar -sCLfc && break || tries=$((tries+1))
+        done
 
     - name: Install and create standalone package
       working-directory: ./MSYS2/gtk${{ matrix.gtk }}
@@ -64,5 +72,5 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         tag: 'nightly'
-        rm: false
+        rm: true
         files: artifact/*

--- a/MSYS2/gtk2/PKGBUILD
+++ b/MSYS2/gtk2/PKGBUILD
@@ -5,12 +5,17 @@ pkgver=ci
 pkgrel=1
 pkgdesc="GtkWave, a fully featured GTK+ based wave viewer which reads VCD, GHW, LXT, LXT2, VZT and FST files"
 arch=('any')
-depends=("${MINGW_PACKAGE_PREFIX}-gtk2"
-         "${MINGW_PACKAGE_PREFIX}-tk"
-         "${MINGW_PACKAGE_PREFIX}-tklib-git"
-         "${MINGW_PACKAGE_PREFIX}-tcl"
-         "${MINGW_PACKAGE_PREFIX}-tcllib")
-makedepends=('perlxml' 'intltool')
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-gtk2"
+  "${MINGW_PACKAGE_PREFIX}-tk"
+  "${MINGW_PACKAGE_PREFIX}-tklib"
+  "${MINGW_PACKAGE_PREFIX}-tcl"
+  "${MINGW_PACKAGE_PREFIX}-tcllib"
+)
+makedepends=(
+  'perlxml'
+  'intltool'
+)
 
 prepare() {
   cp -r "../../../gtkwave3" "${srcdir}"

--- a/MSYS2/gtk3/PKGBUILD
+++ b/MSYS2/gtk3/PKGBUILD
@@ -5,12 +5,17 @@ pkgver=ci
 pkgrel=1
 pkgdesc="GtkWave, a fully featured GTK+ based wave viewer which reads VCD, GHW, LXT, LXT2, VZT and FST files"
 arch=('any')
-depends=("${MINGW_PACKAGE_PREFIX}-gtk3"
-         "${MINGW_PACKAGE_PREFIX}-tk"
-         "${MINGW_PACKAGE_PREFIX}-tklib-git"
-         "${MINGW_PACKAGE_PREFIX}-tcl"
-         "${MINGW_PACKAGE_PREFIX}-tcllib")
-makedepends=('perlxml' 'intltool')
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-gtk3"
+  "${MINGW_PACKAGE_PREFIX}-tk"
+  "${MINGW_PACKAGE_PREFIX}-tklib"
+  "${MINGW_PACKAGE_PREFIX}-tcl"
+  "${MINGW_PACKAGE_PREFIX}-tcllib"
+)
+makedepends=(
+  'perlxml'
+  'intltool'
+)
 
 prepare() {
   cp -r "../../../gtkwave3-gtk3" "${srcdir}"


### PR DESCRIPTION
CI was failing because package `tklib-git` is not available anymore. It's now `tklib`. That's fixed in this PR. At the same time, due to the arbitrary compiler crashes, each build is retried three times.