### PR TITLE
Support building fstapi using Microsoft MSVC compiler

### DIFF
--- a/gtkwave3/src/helpers/fst/CMakeLists.txt
+++ b/gtkwave3/src/helpers/fst/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required (VERSION 3.0)
+
+project (fstlib)
+
+########################################################################################################################
+# Easiest way to get ZLib on windows is using vcpkg, to load vcpkg:
+# cmake -DCMAKE_TOOLCHAIN_FILE=[path to vcpkg]/scripts/buildsystems/vcpkg.cmake
+if(CMAKE_TOOLCHAIN_FILE)
+    message(STATUS "Using VCPKG from ${CMAKE_TOOLCHAIN_FILE}")
+endif()
+########################################################################################################################
+find_package(ZLIB REQUIRED)
+
+add_library(fstapi fstapi.c fstapi.h fst_win_unistd.h)
+target_link_libraries(fstapi PRIVATE ZLIB::ZLIB)
+# hack to avoid creating dummy config.h
+target_compile_definitions(fstapi PRIVATE -DFST_CONFIG_INCLUDE="fstapi.h")
+
+if(MSVC)
+    # define __MINGW32__ to minimize changes to upstream
+    target_compile_definitions(fstapi PRIVATE __MINGW32__  _CRT_SECURE_NO_WARNINGS  FST_DO_MISALIGNED_OPS)
+    target_compile_options(fstapi PRIVATE /wd4244 /wd4267 /wd4146 /wd4996)
+endif()

--- a/gtkwave3/src/helpers/fst/fst_win_unistd.h
+++ b/gtkwave3/src/helpers/fst/fst_win_unistd.h
@@ -1,0 +1,28 @@
+#ifndef WIN_UNISTD_H
+#define WIN_UNISTD_H
+
+#include <stdlib.h>
+#ifdef _WIN64
+#include <io.h>
+#else
+#include <sys/io.h>
+#endif
+
+#include <process.h>
+
+#define ftruncate _chsize_s
+#define unlink _unlink
+#define fileno _fileno
+#define lseek _lseeki64
+
+#ifdef _WIN64
+#define ssize_t __int64
+#define SSIZE_MAX 9223372036854775807i64
+#else
+#define ssize_t long
+#define SSIZE_MAX 2147483647L
+#endif
+
+#include "stdint.h"
+
+#endif //WIN_UNISTD_H

--- a/gtkwave3/src/helpers/fst/fstapi.c
+++ b/gtkwave3/src/helpers/fst/fstapi.c
@@ -80,6 +80,12 @@
 #define PATH_MAX (4096)
 #endif
 
+#if defined(_MSC_VER)
+typedef int64_t fst_off_t;
+#else
+typedef off_t fst_off_t;
+#endif
+
 /* note that Judy versus Jenkins requires more experimentation: they are  */
 /* functionally equivalent though it appears Jenkins is slightly faster.  */
 /* in addition, Jenkins is not bound by the LGPL.                         */
@@ -155,8 +161,8 @@ void **JenkinsIns(void *base_i, const unsigned char *mem, uint32_t length, uint3
 #ifdef __MINGW32__
 #include <io.h>
 #ifndef HAVE_FSEEKO
-#define ftello ftell
-#define fseeko fseek
+#define ftello _ftelli64
+#define fseeko _fseeki64
 #endif
 #endif
 
@@ -284,7 +290,7 @@ static size_t fstFwrite(const void *buf, size_t siz, size_t cnt, FILE *fp)
 return(fwrite(buf, siz, cnt, fp));
 }
 
-static int fstFtruncate(int fd, off_t length)
+static int fstFtruncate(int fd, fst_off_t length)
 {
 return(ftruncate(fd, length));
 }
@@ -329,12 +335,12 @@ return(NULL);
 #define fstMmap(__addr,__len,__prot,__flags,__fd,__off) fstMmap2((__len), (__fd), (__off))
 #define fstMunmap(__addr,__len)                         free(__addr)
 
-static void *fstMmap2(size_t __len, int __fd, off_t __off)
+static void *fstMmap2(size_t __len, int __fd, fst_off_t __off)
 {
 (void)__off;
 
 unsigned char *pnt = (unsigned char *)malloc(__len);
-off_t cur_offs = lseek(__fd, 0, SEEK_CUR);
+fst_off_t cur_offs = lseek(__fd, 0, SEEK_CUR);
 size_t i;
 
 lseek(__fd, 0, SEEK_SET);
@@ -734,7 +740,7 @@ FILE *tchn_handle;
 
 unsigned char *vchg_mem;
 
-off_t hier_file_len;
+fst_off_t hier_file_len;
 
 uint32_t *valpos_mem;
 unsigned char *curval_mem;
@@ -754,7 +760,7 @@ unsigned fourpack : 1;
 unsigned fastpack : 1;
 
 int64_t timezero;
-off_t section_header_truncpos;
+fst_off_t section_header_truncpos;
 uint32_t tchn_cnt, tchn_idx;
 uint64_t curtime;
 uint64_t firsttime;
@@ -762,7 +768,7 @@ uint32_t vchg_siz;
 uint32_t vchg_alloc_siz;
 
 uint32_t secnum;
-off_t section_start;
+fst_off_t section_start;
 
 uint32_t numscopes;
 double nan; /* nan value for uninitialized doubles */
@@ -820,7 +826,7 @@ fstEnumHandle max_enumhandle;
 };
 
 
-static int fstWriterFseeko(struct fstWriterContext *xc, FILE *stream, off_t offset, int whence)
+static int fstWriterFseeko(struct fstWriterContext *xc, FILE *stream, fst_off_t offset, int whence)
 {
 int rc = fseeko(stream, offset, whence);
 
@@ -987,7 +993,7 @@ if(pnt == MAP_FAILED)
 
 static void fstWriterCreateMmaps(struct fstWriterContext *xc)
 {
-off_t curpos = ftello(xc->handle);
+fst_off_t curpos = ftello(xc->handle);
 
 fflush(xc->hier_handle);
 
@@ -1041,7 +1047,7 @@ if(xc->curval_mem)
                 {
                 unsigned char *pnt = xc->curval_mem;
                 int __fd = fileno(xc->curval_handle);
-                off_t cur_offs = lseek(__fd, 0, SEEK_CUR);
+                fst_off_t cur_offs = lseek(__fd, 0, SEEK_CUR);
                 size_t i;
                 size_t __len = xc->maxvalpos;
 
@@ -1282,14 +1288,14 @@ int cnt = 0;
 unsigned int i;
 unsigned char *vchg_mem;
 FILE *f;
-off_t fpos, indxpos, endpos;
+fst_off_t fpos, indxpos, endpos;
 uint32_t prevpos;
 int zerocnt;
 unsigned char *scratchpad;
 unsigned char *scratchpnt;
 unsigned char *tmem;
-off_t tlen;
-off_t unc_memreq = 0; /* for reader */
+fst_off_t tlen;
+fst_off_t unc_memreq = 0; /* for reader */
 unsigned char *packmem;
 unsigned int packmemlen;
 uint32_t *vm4ip;
@@ -1733,7 +1739,7 @@ if(tmem)
         unsigned char *dmem = (unsigned char *)malloc(compressBound(destlen));
         int rc = compress2(dmem, &destlen, tmem, tlen, 9);
 
-        if((rc == Z_OK) && (((off_t)destlen) < tlen))
+        if((rc == Z_OK) && (((fst_off_t)destlen) < tlen))
                 {
                 fstFwrite(dmem, destlen, 1, xc->handle);
                 }
@@ -1781,7 +1787,7 @@ fstWriterFseeko(xc, xc->handle, endpos, SEEK_SET);                              
 xc2->section_header_truncpos = endpos;                          /* cache in case of need to truncate */
 if(xc->dump_size_limit)
         {
-        if(endpos >= ((off_t)xc->dump_size_limit))
+        if(endpos >= ((fst_off_t)xc->dump_size_limit))
                 {
                 xc2->skip_writing_section_hdr = 1;
                 xc2->size_limit_locked = 1;
@@ -1931,7 +1937,7 @@ if(xc)
 if(xc && !xc->already_in_close && !xc->already_in_flush)
         {
         unsigned char *tmem = NULL;
-        off_t fixup_offs, tlen, hlen;
+        fst_off_t fixup_offs, tlen, hlen;
 
         xc->already_in_close = 1; /* never need to zero this out as it is freed at bottom */
 
@@ -1991,7 +1997,7 @@ if(xc && !xc->already_in_close && !xc->already_in_flush)
                 unsigned char *dmem = (unsigned char *)malloc(compressBound(destlen));
                 int rc = compress2(dmem, &destlen, tmem, tlen, 9);
 
-                if((rc != Z_OK) || (((off_t)destlen) > tlen))
+                if((rc != Z_OK) || (((fst_off_t)destlen) > tlen))
                         {
                         destlen = tlen;
                         }
@@ -2002,7 +2008,7 @@ if(xc && !xc->already_in_close && !xc->already_in_flush)
                 fstWriterUint64(xc->handle, tlen);              /* uncompressed */
                                                                 /* compressed len is section length - 24 */
                 fstWriterUint64(xc->handle, xc->maxhandle);     /* maxhandle */
-                fstFwrite((((off_t)destlen) != tlen) ? dmem : tmem, destlen, 1, xc->handle);
+                fstFwrite((((fst_off_t)destlen) != tlen) ? dmem : tmem, destlen, 1, xc->handle);
                 fflush(xc->handle);
 
                 fstWriterFseeko(xc, xc->handle, fixup_offs, SEEK_SET);
@@ -2018,7 +2024,7 @@ if(xc && !xc->already_in_close && !xc->already_in_flush)
         if(xc->num_blackouts)
                 {
                 uint64_t cur_bl = 0;
-                off_t bpos, eos;
+                fst_off_t bpos, eos;
                 uint32_t i;
 
                 fixup_offs = ftello(xc->handle);
@@ -2051,7 +2057,7 @@ if(xc && !xc->already_in_close && !xc->already_in_flush)
 
         if(xc->compress_hier)
                 {
-                off_t hl, eos;
+                fst_off_t hl, eos;
                 gzFile zhandle;
                 int zfd;
                 int fourpack_duo = 0;
@@ -2174,7 +2180,7 @@ if(xc && !xc->already_in_close && !xc->already_in_flush)
                 if(xc->repack_on_close)
                         {
                         FILE *fp;
-                        off_t offpnt, uclen;
+                        fst_off_t offpnt, uclen;
                         int flen = strlen(xc->filename);
                         char *hf = (char *)calloc(1, flen + 5);
 
@@ -2281,7 +2287,7 @@ struct fstWriterContext *xc = (struct fstWriterContext *)ctx;
 if(xc)
         {
         char s[FST_HDR_DATE_SIZE];
-        off_t fpos = ftello(xc->handle);
+        fst_off_t fpos = ftello(xc->handle);
         int len = strlen(dat);
 
         fstWriterFseeko(xc, xc->handle, FST_HDR_OFFS_DATE, SEEK_SET);
@@ -2300,7 +2306,7 @@ struct fstWriterContext *xc = (struct fstWriterContext *)ctx;
 if(xc && vers)
         {
         char s[FST_HDR_SIM_VERSION_SIZE];
-        off_t fpos = ftello(xc->handle);
+        fst_off_t fpos = ftello(xc->handle);
         int len = strlen(vers);
 
         fstWriterFseeko(xc, xc->handle, FST_HDR_OFFS_SIM_VERSION, SEEK_SET);
@@ -2320,7 +2326,7 @@ if(xc)
         {
         if(/*(filetype >= FST_FT_MIN) &&*/ (filetype <= FST_FT_MAX))
                 {
-                off_t fpos = ftello(xc->handle);
+                fst_off_t fpos = ftello(xc->handle);
 
                 xc->filetype = filetype;
 
@@ -2461,7 +2467,7 @@ void fstWriterSetTimescale(void *ctx, int ts)
 struct fstWriterContext *xc = (struct fstWriterContext *)ctx;
 if(xc)
         {
-        off_t fpos = ftello(xc->handle);
+        fst_off_t fpos = ftello(xc->handle);
         fstWriterFseeko(xc, xc->handle, FST_HDR_OFFS_TIMESCALE, SEEK_SET);
         fputc(ts & 255, xc->handle);
         fflush(xc->handle);
@@ -2519,7 +2525,7 @@ void fstWriterSetTimezero(void *ctx, int64_t tim)
 struct fstWriterContext *xc = (struct fstWriterContext *)ctx;
 if(xc)
         {
-        off_t fpos = ftello(xc->handle);
+        fst_off_t fpos = ftello(xc->handle);
         fstWriterFseeko(xc, xc->handle, FST_HDR_OFFS_TIMEZERO, SEEK_SET);
         fstWriterUint64(xc->handle, (xc->timezero = tim));
         fflush(xc->handle);
@@ -3361,7 +3367,7 @@ char date[FST_HDR_DATE_SIZE + 1];
 int64_t timezero;
 
 char *filename, *filename_unpacked;
-off_t hier_pos;
+fst_off_t hier_pos;
 
 uint32_t num_blackouts;
 uint64_t *blackout_times;
@@ -3376,10 +3382,10 @@ uint64_t *rvat_time_table;
 uint64_t rvat_beg_tim, rvat_end_tim;
 unsigned char *rvat_frame_data;
 uint64_t rvat_frame_maxhandle;
-off_t *rvat_chain_table;
+fst_off_t *rvat_chain_table;
 uint32_t *rvat_chain_table_lengths;
 uint64_t rvat_vc_maxhandle;
-off_t rvat_vc_start;
+fst_off_t rvat_vc_start;
 uint32_t *rvat_sig_offs;
 int rvat_packtype;
 
@@ -3418,7 +3424,7 @@ char *fh_nam;
 };
 
 
-int fstReaderFseeko(struct fstReaderContext *xc, FILE *stream, off_t offset, int whence)
+int fstReaderFseeko(struct fstReaderContext *xc, FILE *stream, fst_off_t offset, int whence)
 {
 int rc = fseeko(stream, offset, whence);
 
@@ -3911,11 +3917,11 @@ int pass_status = 1;
 
 if(!xc->fh)
         {
-        off_t offs_cache = ftello(xc->f);
+        fst_off_t offs_cache = ftello(xc->f);
         char *fnam = (char *)malloc(strlen(xc->filename) + 6 + 16 + 32 + 1);
         unsigned char *mem = (unsigned char *)malloc(FST_GZIO_LEN);
-        off_t hl, uclen;
-        off_t clen = 0;
+        fst_off_t hl, uclen;
+        fst_off_t clen = 0;
         gzFile zhandle = NULL;
         int zfd;
         int htyp = FST_BL_SKIP;
@@ -4535,8 +4541,8 @@ return(1);
  */
 int fstReaderInit(struct fstReaderContext *xc)
 {
-off_t blkpos = 0;
-off_t endfile;
+fst_off_t blkpos = 0;
+fst_off_t endfile;
 uint64_t seclen;
 int sectype;
 uint64_t vc_section_count_actual = 0;
@@ -4548,7 +4554,7 @@ sectype = fgetc(xc->f);
 if(sectype == FST_BL_ZWRAPPER)
         {
         FILE *fcomp;
-        off_t offpnt, uclen;
+        fst_off_t offpnt, uclen;
         char gz_membuf[FST_GZIO_LEN];
         gzFile zhandle;
         int zfd;
@@ -4981,15 +4987,15 @@ uint64_t *time_table = NULL;
 uint64_t tsec_nitems;
 unsigned int secnum = 0;
 int blocks_skipped = 0;
-off_t blkpos = 0;
+fst_off_t blkpos = 0;
 uint64_t seclen, beg_tim;
 #ifdef FST_DEBUG
 uint64_t end_tim;
 #endif
 uint64_t frame_uclen, frame_clen, frame_maxhandle, vc_maxhandle;
-off_t vc_start;
-off_t indx_pntr, indx_pos;
-off_t *chain_table = NULL;
+fst_off_t vc_start;
+fst_off_t indx_pntr, indx_pos;
+fst_off_t *chain_table = NULL;
 uint32_t *chain_table_lengths = NULL;
 unsigned char *chain_cmem;
 unsigned char *pnt;
@@ -5105,7 +5111,7 @@ for(;;)
         destlen = tsec_uclen;
         sourcelen = tsec_clen;
 
-        fstReaderFseeko(xc, xc->f, -24 - ((off_t)tsec_clen), SEEK_CUR);
+        fstReaderFseeko(xc, xc->f, -24 - ((fst_off_t)tsec_clen), SEEK_CUR);
 
         if(tsec_uclen != tsec_clen)
                 {
@@ -5346,11 +5352,11 @@ for(;;)
                                 }
 
                         free(mu);
-                        fstReaderFseeko(xc, xc->f, -((off_t)frame_clen), SEEK_CUR);
+                        fstReaderFseeko(xc, xc->f, -((fst_off_t)frame_clen), SEEK_CUR);
                         }
                 }
 
-        fstReaderFseeko(xc, xc->f, (off_t)frame_clen, SEEK_CUR); /* skip past compressed data */
+        fstReaderFseeko(xc, xc->f, (fst_off_t)frame_clen, SEEK_CUR); /* skip past compressed data */
 
         vc_maxhandle = fstReaderVarint64(xc->f);
         vc_start = ftello(xc->f);       /* points to '!' character */
@@ -5380,7 +5386,7 @@ for(;;)
                 free(chain_table_lengths);
 
                 vc_maxhandle_largest = vc_maxhandle;
-                chain_table = (off_t *)calloc((vc_maxhandle+1), sizeof(off_t));
+                chain_table = (fst_off_t *)calloc((vc_maxhandle+1), sizeof(fst_off_t));
                 chain_table_lengths = (uint32_t *)calloc((vc_maxhandle+1), sizeof(uint32_t));
                 }
 
@@ -6001,7 +6007,7 @@ return(buf);
 char *fstReaderGetValueFromHandleAtTime(void *ctx, uint64_t tim, fstHandle facidx, char *buf)
 {
 struct fstReaderContext *xc = (struct fstReaderContext *)ctx;
-off_t blkpos = 0, prev_blkpos;
+fst_off_t blkpos = 0, prev_blkpos;
 uint64_t beg_tim, end_tim, beg_tim2, end_tim2;
 int sectype;
 unsigned int secnum = 0;
@@ -6012,7 +6018,7 @@ uint64_t frame_uclen, frame_clen;
 #ifdef FST_DEBUG
 uint64_t mem_required_for_traversal;
 #endif
-off_t indx_pntr, indx_pos;
+fst_off_t indx_pntr, indx_pos;
 long chain_clen;
 unsigned char *chain_cmem;
 unsigned char *pnt;
@@ -6074,7 +6080,7 @@ for(;;)
                 {
                 if((tim == end_tim) && (tim != xc->end_time))
                         {
-                        off_t cached_pos = ftello(xc->f);
+                        fst_off_t cached_pos = ftello(xc->f);
                         fstReaderFseeko(xc, xc->f, blkpos, SEEK_SET);
 
                         sectype = fgetc(xc->f);
@@ -6136,7 +6142,7 @@ ucdata = (unsigned char *)malloc(tsec_uclen);
 destlen = tsec_uclen;
 sourcelen = tsec_clen;
 
-fstReaderFseeko(xc, xc->f, -24 - ((off_t)tsec_clen), SEEK_CUR);
+fstReaderFseeko(xc, xc->f, -24 - ((fst_off_t)tsec_clen), SEEK_CUR);
 if(tsec_uclen != tsec_clen)
         {
         cdata = (unsigned char *)malloc(tsec_clen);
@@ -6221,7 +6227,7 @@ chain_cmem = (unsigned char *)malloc(chain_clen);
 fstReaderFseeko(xc, xc->f, indx_pos, SEEK_SET);
 fstFread(chain_cmem, chain_clen, 1, xc->f);
 
-xc->rvat_chain_table = (off_t *)calloc((xc->rvat_vc_maxhandle+1), sizeof(off_t));
+xc->rvat_chain_table = (fst_off_t *)calloc((xc->rvat_vc_maxhandle+1), sizeof(fst_off_t));
 xc->rvat_chain_table_lengths = (uint32_t *)calloc((xc->rvat_vc_maxhandle+1), sizeof(uint32_t));
 
 pnt = chain_cmem;

--- a/gtkwave3/src/helpers/fst/fstapi.h
+++ b/gtkwave3/src/helpers/fst/fstapi.h
@@ -35,7 +35,11 @@ extern "C" {
 #include <ctype.h>
 #include <zlib.h>
 #include <inttypes.h>
-#include <unistd.h>
+#if defined(_MSC_VER)
+    #include "fst_win_unistd.h"
+#else
+    #include <unistd.h>
+#endif
 #include <time.h>
 
 #define FST_RDLOAD "FSTLOAD | "


### PR DESCRIPTION
GtkWave does not support Visual Studio builds, but MSYS2 builds work well on Windows.
However it may be useful to integrate FST waveform dumps into simulators developed with Visual Studio.
It mostly works out-of-the box. The only issue I had to debug is waveforms get corrupted
when size of FST grows larger than 2.1 GB. It turned out off_t is 32bit on Windows.
Replaced it with int64_t to have consistent behavior with Windows and Linux builds.