### PR TITLE
Improve drawing of filled waveforms

### DIFF
--- a/gtkwave3-gtk3/src/wavewindow.c
+++ b/gtkwave3-gtk3/src/wavewindow.c
@@ -264,13 +264,14 @@ cairo_stroke (cr);
 void XXX_gdk_draw_rectangle(cairo_t *cr, wave_rgb_t gc, gboolean filled, gint _x1, gint _y1, gint _w, gint _h)
 {
 cairo_set_source_rgba (cr, gc.r, gc.g, gc.b, gc.a);
-cairo_rectangle (cr, _x1+WAVE_CAIRO_050_OFFSET, _y1+WAVE_CAIRO_050_OFFSET, _w, _h);
 if(filled)
 	{
+	cairo_rectangle (cr, _x1, _y1, _w, _h);
         cairo_fill(cr);
 	}
 	else
 	{
+	cairo_rectangle (cr, _x1+WAVE_CAIRO_050_OFFSET, _y1+WAVE_CAIRO_050_OFFSET, _w, _h);
         cairo_stroke(cr);
 	}
 }
@@ -611,6 +612,7 @@ GdkDrawingContext *gdc;
 #endif
 cairo_t* cr = XXX_gdk_cairo_create (XXX_GDK_DRAWABLE (gtk_widget_get_window(GLOBALS->wavearea)), &gdc);
 cairo_set_line_width(cr, GLOBALS->cr_line_width);
+cairo_set_line_cap(cr, CAIRO_LINE_CAP_SQUARE);
 
 GLOBALS->m1x_wavewindow_c_1=GLOBALS->m2x_wavewindow_c_1=-1;
 
@@ -1850,6 +1852,7 @@ if(GLOBALS->cr_wavepixmap_wavewindow_c_1)
                 GLOBALS->cr_wavepixmap_wavewindow_c_1 = cairo_create (GLOBALS->surface_wavepixmap_wavewindow_c_1);
                 cairo_scale(GLOBALS->cr_wavepixmap_wavewindow_c_1, scale_factor, scale_factor);
                 cairo_set_line_width(GLOBALS->cr_wavepixmap_wavewindow_c_1, GLOBALS->cr_line_width);
+		cairo_set_line_cap(GLOBALS->cr_wavepixmap_wavewindow_c_1, CAIRO_LINE_CAP_SQUARE);
 		}
 	GLOBALS->old_wvalue=-1.0;
 	}
@@ -1862,6 +1865,7 @@ if(GLOBALS->cr_wavepixmap_wavewindow_c_1)
         GLOBALS->cr_wavepixmap_wavewindow_c_1 = cairo_create (GLOBALS->surface_wavepixmap_wavewindow_c_1);
         cairo_scale(GLOBALS->cr_wavepixmap_wavewindow_c_1, scale_factor, scale_factor);
         cairo_set_line_width(GLOBALS->cr_wavepixmap_wavewindow_c_1, GLOBALS->cr_line_width);
+	cairo_set_line_cap(GLOBALS->cr_wavepixmap_wavewindow_c_1, CAIRO_LINE_CAP_SQUARE);
 	}
 
 if(!GLOBALS->made_gc_contexts_wavewindow_c_1)


### PR DESCRIPTION
This PR improves the drawing of filled waveforms. The current code doesn't correctly align the filled rectangle with the pixel grid, which causes some blurring at the edges. This is especially noticeable in black and white mode.

Before (UI scaling: 1, scaled 4x in GIMP)
![grafik](https://user-images.githubusercontent.com/226123/130366615-9647d396-4751-4571-9239-86c751962a11.png)

After:
![grafik](https://user-images.githubusercontent.com/226123/130366721-042e3d55-d055-4688-afaf-2d6cc26916ae.png)

I've also changed the line cap to square, which removes some gaps in the display and results in a crisper display:

Before (UI scaling: 3):
![grafik](https://user-images.githubusercontent.com/226123/130366923-87065a03-dec8-4874-8f97-1f6e91f8b55a.png)
After:
![grafik](https://user-images.githubusercontent.com/226123/130366937-5dceaf36-6cb4-4a47-b7a7-286651353793.png)
