### PR TITLE
Use GtkSearchEntry in SST

### DIFF
--- a/gtkwave3-gtk3/src/main.c
+++ b/gtkwave3-gtk3/src/main.c
@@ -314,7 +314,7 @@ if(!GLOBALS->disable_menus)
 			gtk_widget_show(pan_dn);
 			gtk_tooltips_set_tip_2(pan_dn, "Show toolbar");
 	
-			GtkWidget *fs = gtk_button_new_from_icon_name("view-fullscreen", GTK_ICON_SIZE_BUTTON);
+			GtkWidget *fs = gtk_button_new_from_icon_name("view-fullscreen-symbolic", GTK_ICON_SIZE_BUTTON);
 			gtk_header_bar_pack_end(GTK_HEADER_BAR(GLOBALS->header_bar),fs);
 			gtk_widget_show(fs);
 			gtk_tooltips_set_tip_2(fs, "Fullscreen");

--- a/gtkwave3-gtk3/src/treesearch.c
+++ b/gtkwave3-gtk3/src/treesearch.c
@@ -1546,7 +1546,7 @@ GtkWidget* treeboxframe(char *title, GCallback func)
     GtkWidget *scrolled_win, *sig_scroll_win;
     GtkWidget *hbox;
     GtkWidget *button1, *button2, *button4;
-    GtkWidget *frameh, *sig_frame;
+    GtkWidget *sig_frame;
     GtkWidget *vbox, *vpan, *filter_hbox;
     GtkWidget *filter_label;
     GtkWidget *sig_view;
@@ -1693,13 +1693,14 @@ GtkWidget* treeboxframe(char *title, GCallback func)
 
     /* Filter.  */
     filter_hbox = XXX_gtk_hbox_new (FALSE, 1);
+    gtk_container_set_border_width (GTK_CONTAINER (filter_hbox), 2);
     gtk_widget_show (filter_hbox);
 
-    filter_label = gtk_label_new ("Filter:");
-    gtk_widget_show (filter_label);
-    gtk_box_pack_start (GTK_BOX (filter_hbox), filter_label, FALSE, FALSE, 1);
-
+#if GTK_CHECK_VERSION(3,0,0)
+    GLOBALS->filter_entry = gtk_search_entry_new ();
+#else
     GLOBALS->filter_entry = gtk_entry_new ();
+#endif
     if(GLOBALS->filter_str_treesearch_gtk2_c_1) { gtk_entry_set_text(GTK_ENTRY(GLOBALS->filter_entry), GLOBALS->filter_str_treesearch_gtk2_c_1); }
     gtk_widget_show (GLOBALS->filter_entry);
 
@@ -1720,18 +1721,11 @@ GtkWidget* treeboxframe(char *title, GCallback func)
 	   " The filter may be preceded with the port direction if it exists such as ++ (show only non-port), +I+, +O+, +IO+, etc."
 	   " Use -- to exclude all non-ports (i.e., show only all ports), -I- to exclude all input ports, etc."
 	   );
-
-    gtk_box_pack_start (GTK_BOX (filter_hbox), GLOBALS->filter_entry, FALSE, FALSE, 1);
+    gtk_box_pack_start (GTK_BOX (filter_hbox), GLOBALS->filter_entry, TRUE, TRUE, 1);
 
     gtk_box_pack_start (GTK_BOX (vbox), filter_hbox, FALSE, FALSE, 1);
 
     /* Buttons.  */
-    frameh = gtk_frame_new (NULL);
-    gtk_container_set_border_width (GTK_CONTAINER (frameh), 3);
-    gtk_widget_show(frameh);
-    gtk_box_pack_start (GTK_BOX (vbox), frameh, FALSE, FALSE, 1);
-
-
     hbox = XXX_gtk_hbox_new (FALSE, 1);
     gtk_widget_show (hbox);
 
@@ -1760,7 +1754,7 @@ GtkWidget* treeboxframe(char *title, GCallback func)
 		"Replace highlighted signals on the main window with signals selected above.");
     gtk_box_pack_start (GTK_BOX (hbox), button4, TRUE, FALSE, 0);
 
-    gtk_container_add (GTK_CONTAINER (frameh), hbox);
+    gtk_box_pack_start (GTK_BOX (vbox), hbox, FALSE, FALSE, 1);
     return vbox;
 }
 


### PR DESCRIPTION
This PR replaces the regular GtkEntry in the SST sidebar with a GtkSearchEntry. The search entry contains a search icon, which makes the "Filter:" label redundant. By removing the label and the frame around the buttons the UI looks cleaner.

If you think that PRs like this are useful I would like to continue to tweak the UI/UX in further PRs. But this is made harder by having to maintain the backward compatibility with GTK 2. Do you plan to remove the GTK 2 support from "gtkwave3-gtk3" at some point?

There are two functions which build a similar SST widget: `treebox` and `treeboxframe`. Is the separate `treebox` window still accessible in the GTK3 version? I've only modified `treeboxframe` in this PR.

Before:
![Bildschirmfoto vom 2021-08-23 19-16-10](https://user-images.githubusercontent.com/226123/130489644-55be2c85-ab2b-4843-baab-070cc7b87804.png)

After:
![Bildschirmfoto vom 2021-08-23 19-16-53](https://user-images.githubusercontent.com/226123/130489648-6933f710-58a4-4fb3-ad21-a2badc2ee98e.png)
