### PR TITLE
Implement entrybox using GTK dialog

### DIFF
--- a/gtkwave3-gtk3/src/entry.c
+++ b/gtkwave3-gtk3/src/entry.c
@@ -10,192 +10,96 @@
 #include "globals.h"
 #include <config.h>
 #include <gtk/gtk.h>
-#include "gtk23compat.h"
 #include "menu.h"
 #include "debug.h"
-#include <cocoa_misc.h>
 #include <string.h>
 
-#ifdef MAC_INTEGRATION
-/* disabled for now as we can't get it to auto enable when it comes up */
-#define WAVE_MAC_USE_ENTRY
-#endif
-
-#ifndef WAVE_MAC_USE_ENTRY
-static gint keypress_local(GtkWidget *widget, GdkEventKey *event, gpointer data)
+static void entry_activate(GtkWidget *widget, GtkWidget *dialog)
 {
-(void)widget;
-(void)event;
-(void)data;
-
-if(GLOBALS->window_entry_c_1)
-	{
-	gdk_window_raise(gtk_widget_get_window(GLOBALS->window_entry_c_1));
-	}
-
-return(FALSE);
+    gtk_dialog_response (GTK_DIALOG(dialog), GTK_RESPONSE_OK);
 }
-#endif
-
-#ifndef WAVE_MAC_USE_ENTRY
-static void enter_callback(GtkWidget *widget, GtkWidget *nothing)
-{
-(void)widget;
-(void)nothing;
-
-  G_CONST_RETURN gchar *entry_text;
-  int len;
-  entry_text = gtk_entry_get_text(GTK_ENTRY(GLOBALS->entry_entry_c_1));
-  entry_text = entry_text ? entry_text : "";
-  DEBUG(printf("Entry contents: %s\n", entry_text));
-  if(!(len=strlen(entry_text))) GLOBALS->entrybox_text=NULL;
-	else strcpy((GLOBALS->entrybox_text=(char *)malloc_2(len+1)),entry_text);
-
-  wave_gtk_grab_remove(GLOBALS->window_entry_c_1);
-  gtk_widget_destroy(GLOBALS->window_entry_c_1);
-  GLOBALS->window_entry_c_1 = NULL;
-
-  GLOBALS->cleanup_entry_c_1();
-}
-
-static void destroy_callback(GtkWidget *widget, GtkWidget *nothing)
-{
-(void)widget;
-(void)nothing;
-
-  DEBUG(printf("Entry Cancel\n"));
-  GLOBALS->entrybox_text=NULL;
-  wave_gtk_grab_remove(GLOBALS->window_entry_c_1);
-  gtk_widget_destroy(GLOBALS->window_entry_c_1);
-  GLOBALS->window_entry_c_1 = NULL;
-}
-#endif
 
 void entrybox(char *title, int width, char *dflt_text, char *comment, int maxch, GCallback func)
 {
-#ifndef WAVE_MAC_USE_ENTRY
-    GtkWidget *vbox, *hbox;
-    GtkWidget *button1, *button2;
-/*  int height = (comment) ? 75 : 60; */
-    int height = -1; /* changed as recent gnome themes have taller window title bars so 75 is not enough */
-#endif
+    GtkWidget *dialog;
+    GtkDialogFlags flags;
+    GtkWidget *content;
+    GtkWidget *entry;
 
-    GLOBALS->cleanup_entry_c_1=func;
+    if (GLOBALS->entrybox_text != NULL) {
+        free_2 (GLOBALS->entrybox_text);
+        GLOBALS->entrybox_text = NULL;
+    }
 
-    /* fix problem where ungrab doesn't occur if button pressed + simultaneous accelerator key occurs */
-    if(GLOBALS->in_button_press_wavewindow_c_1) 
-	{ 
-     	XXX_gdk_pointer_ungrab(GDK_CURRENT_TIME);
-	}
-
-    if(GLOBALS->wave_script_args)
-	{
+    if (GLOBALS->wave_script_args) {
         char *s = NULL;
 
-        while((!s)&&(GLOBALS->wave_script_args->curr)) s = wave_script_args_fgetmalloc_stripspaces(GLOBALS->wave_script_args);
-	if(s)
-		{
-		fprintf(stderr, "GTKWAVE | Entry '%s'\n", s);
-		GLOBALS->entrybox_text = s;
-		GLOBALS->cleanup_entry_c_1();
+        while (s == NULL && GLOBALS->wave_script_args->curr != NULL)
+            s = wave_script_args_fgetmalloc_stripspaces (GLOBALS->wave_script_args);
+
+    	if(s) {
+            fprintf (stderr, "GTKWAVE | Entry '%s'\n", s);
+            GLOBALS->entrybox_text = s;
+            func ();
+		} else {
+		    GLOBALS->entrybox_text = NULL;
 		}
-		else
-		{
-		GLOBALS->entrybox_text = NULL;
-		}
 
-	return;
+	    return;
 	}
 
-#ifdef WAVE_MAC_USE_ENTRY
-{
-char *out_text_entry = NULL;
-entrybox_req_bridge(title, width, dflt_text, comment, maxch, &out_text_entry);
-if(out_text_entry)
-	{
-	int len=strlen(out_text_entry);
-	if(!len) GLOBALS->entrybox_text=NULL;
-	else strcpy((GLOBALS->entrybox_text=(char *)malloc_2(len+1)),out_text_entry);
-	free(out_text_entry);
-	GLOBALS->cleanup_entry_c_1();
-	}
-	else
-	{
-	GLOBALS->entrybox_text = NULL;
-	}
-return;
-}
+#if GTK_CHECK_VERSION(3,12,0)
+    flags = GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_USE_HEADER_BAR;
 #else
-
-    /* create a new modal window */
-    GLOBALS->window_entry_c_1 = gtk_window_new(GLOBALS->disable_window_manager ? GTK_WINDOW_POPUP : GTK_WINDOW_TOPLEVEL);
-    install_focus_cb(GLOBALS->window_entry_c_1, ((char *)&GLOBALS->window_entry_c_1) - ((char *)GLOBALS));
-
-    gtk_widget_set_size_request( GTK_WIDGET (GLOBALS->window_entry_c_1), width, height);
-    gtk_window_set_title(GTK_WINDOW (GLOBALS->window_entry_c_1), title);
-    gtkwave_signal_connect(XXX_GTK_OBJECT (GLOBALS->window_entry_c_1), "delete_event",(GCallback) destroy_callback, NULL);
-    gtk_window_set_resizable(GTK_WINDOW(GLOBALS->window_entry_c_1), FALSE);
-
-    vbox = XXX_gtk_vbox_new (FALSE, 0);
-    gtk_container_add (GTK_CONTAINER (GLOBALS->window_entry_c_1), vbox);
-    gtk_widget_show (vbox);
-
-    if (comment)
-      {
-	GtkWidget *label, *cbox;
-
-	cbox = XXX_gtk_hbox_new (FALSE, 1);
-	gtk_box_pack_start (GTK_BOX (vbox), cbox, FALSE, FALSE, 0);
-	gtk_widget_show (cbox);
-
-	label = gtk_label_new(comment);
-	gtk_widget_show (label);
-
-	gtk_container_add (GTK_CONTAINER (cbox), label);
-	gtk_widget_set_can_default (label, TRUE);
-      }
-
-    GLOBALS->entry_entry_c_1 = X_gtk_entry_new_with_max_length (maxch);
-    gtkwave_signal_connect(XXX_GTK_OBJECT(GLOBALS->entry_entry_c_1), "activate",G_CALLBACK(enter_callback),GLOBALS->entry_entry_c_1);
-    gtk_entry_set_text (GTK_ENTRY (GLOBALS->entry_entry_c_1), dflt_text);
-    gtk_editable_select_region (GTK_EDITABLE (GLOBALS->entry_entry_c_1),0, gtk_entry_get_text_length(GTK_ENTRY(GLOBALS->entry_entry_c_1)));
-    gtk_box_pack_start (GTK_BOX (vbox), GLOBALS->entry_entry_c_1, FALSE, FALSE, 0);
-    gtk_widget_show (GLOBALS->entry_entry_c_1);
-
-    hbox = XXX_gtk_hbox_new (FALSE, 1);
-    gtk_box_pack_start (GTK_BOX (vbox), hbox, FALSE, FALSE, 0);
-    gtk_widget_show (hbox);
-
-    button1 = gtk_button_new_with_label ("OK");
-    gtk_widget_set_size_request(button1, 100, -1);
-    gtkwave_signal_connect(XXX_GTK_OBJECT (button1), "clicked", G_CALLBACK(enter_callback), NULL);
-    gtk_widget_show (button1);
-#if GTK_CHECK_VERSION(3,0,0)
-    gtk_box_pack_start(GTK_BOX(hbox), button1, TRUE, TRUE, 0);
-#else
-    gtk_container_add (GTK_CONTAINER (hbox), button1);
-#endif
-    gtk_widget_set_can_default (button1, TRUE);
-    gtkwave_signal_connect_object (XXX_GTK_OBJECT (button1), "realize", (GCallback) gtk_widget_grab_default, XXX_GTK_OBJECT (button1));
-
-
-    button2 = gtk_button_new_with_label ("Cancel");
-    gtk_widget_set_size_request(button2, 100, -1);
-    gtkwave_signal_connect(XXX_GTK_OBJECT (button2), "clicked", G_CALLBACK(destroy_callback), NULL);
-    gtk_widget_set_can_default (button2, TRUE);
-    gtk_widget_show (button2);
-#if GTK_CHECK_VERSION(3,0,0)
-    gtk_box_pack_end(GTK_BOX(hbox), button2, TRUE, TRUE, 0);
-#else
-    gtk_container_add (GTK_CONTAINER (hbox), button2);
+    flags = GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT;
 #endif
 
-    gtk_widget_show(GLOBALS->window_entry_c_1);
-    wave_gtk_grab_add(GLOBALS->window_entry_c_1);
-    gdk_window_raise(gtk_widget_get_window(GLOBALS->window_entry_c_1));
+    dialog = gtk_dialog_new_with_buttons(
+        title,
+        GTK_WINDOW(GLOBALS->mainwindow),
+        flags,
+        "Cancel",
+        GTK_RESPONSE_CANCEL,
+        "OK",
+        GTK_RESPONSE_OK,
+        NULL
+    );
+    gtk_container_set_border_width (GTK_CONTAINER(dialog), 12);
 
-    g_signal_connect(XXX_GTK_OBJECT(GLOBALS->window_entry_c_1), "key_press_event",G_CALLBACK(keypress_local), NULL);
+    content = gtk_dialog_get_content_area (GTK_DIALOG (dialog));
+    gtk_box_set_spacing (GTK_BOX (content), 6);
 
+    if (comment != NULL) {
+        GtkWidget *label = gtk_label_new (comment);
+#if GTK_CHECK_VERSION(3,16,0)
+        gtk_label_set_xalign (GTK_LABEL(label), 0.0);
 #endif
+        gtk_box_pack_start (GTK_BOX(content), label, FALSE, FALSE, 0);
+    }
+
+    entry = gtk_entry_new ();
+    gtk_entry_set_text (GTK_ENTRY (entry), dflt_text);
+    gtk_entry_set_max_length (GTK_ENTRY(entry), maxch);
+    gtk_widget_set_size_request (entry, width, -1);
+    g_signal_connect (entry, "activate", G_CALLBACK (entry_activate), dialog);
+    gtk_box_pack_start (GTK_BOX(content), entry, FALSE, FALSE, 0);
+
+    gtk_widget_show_all (content);
+
+    int result = gtk_dialog_run (GTK_DIALOG(dialog));
+
+    if (result == GTK_RESPONSE_OK) {
+        const gchar *text = gtk_entry_get_text (GTK_ENTRY (entry));
+        int len = strlen (text);
+
+        if (len > 0) {
+            GLOBALS->entrybox_text = malloc_2 (len + 1);
+            strcpy (GLOBALS->entrybox_text, text);
+        }
+
+        func ();
+    }
+
+    gtk_widget_destroy (dialog);
 }
 

--- a/gtkwave3-gtk3/src/globals.c
+++ b/gtkwave3-gtk3/src/globals.c
@@ -229,11 +229,7 @@ NULL, /* atoi_cont_ptr 78 */
 /*
  * entry.c
  */
-0, /* window_entry_c_1 80 */
-0, /* entry_entry_c_1 81 */
 NULL, /* entrybox_text 82 */
-0, /* cleanup_entry_c_1 83 */
-0, /* entry_raise_timer */
 
 /*
  * extload.c
@@ -2164,7 +2160,6 @@ void reload_into_new_context_2(void)
  widget_only_destroy(&GLOBALS->window_help_c_2); 		/* help.c : reload is gated off during help so this should never execute */
 
  /* windows which in theory should never destroy as they will have grab focus which means reload will not be called */
- widget_ungrab_destroy(&GLOBALS->window_entry_c_1);		/* entry.c */
  widget_ungrab_destroy(&GLOBALS->window1_hiersearch_c_1);	/* hiersearch.c */
  widget_ungrab_destroy(&GLOBALS->window_markerbox_c_4);		/* markerbox.c */
  widget_ungrab_destroy(&GLOBALS->window1_search_c_2);		/* search.c */
@@ -2735,7 +2730,6 @@ void free_and_destroy_page_context(void)
  widget_only_destroy(&GLOBALS->window_help_c_2); 		/* help.c : reload is gated off during help so this should never execute */
 
  /* windows which in theory should never destroy as they will have grab focus which means reload will not be called */
- widget_ungrab_destroy(&GLOBALS->window_entry_c_1);		/* entry.c */
  widget_ungrab_destroy(&GLOBALS->window1_hiersearch_c_1);	/* hiersearch.c */
  widget_ungrab_destroy(&GLOBALS->window_markerbox_c_4);		/* markerbox.c */
  widget_ungrab_destroy(&GLOBALS->window1_search_c_2);		/* search.c */

--- a/gtkwave3-gtk3/src/globals.h
+++ b/gtkwave3-gtk3/src/globals.h
@@ -246,11 +246,7 @@ char disable_tooltips; /* from debug.c 80 */
 /*
  * entry.c
  */
-GtkWidget *window_entry_c_1; /* from entry.c 81 */
-GtkWidget *entry_entry_c_1; /* from entry.c 82 */
 char *entrybox_text; /* from entry.c 83 */
-void (*cleanup_entry_c_1)(void); /* from entry.c 84 */
-int entry_raise_timer;
 
 
 /* extload.c */

--- a/gtkwave3-gtk3/src/signalwindow.c
+++ b/gtkwave3-gtk3/src/signalwindow.c
@@ -1072,16 +1072,6 @@ if(GLOBALS->splash_fix_win_title)
 	wave_gtk_window_set_title(GTK_WINDOW(GLOBALS->mainwindow), GLOBALS->winname, GLOBALS->dumpfile_is_modified ? WAVE_SET_TITLE_MODIFIED: WAVE_SET_TITLE_NONE, 0);
 	}
 
-if(GLOBALS->window_entry_c_1)
-        {
-	GLOBALS->entry_raise_timer++;
-	if(GLOBALS->entry_raise_timer > 50)
-		{
-		gdk_window_raise(gtk_widget_get_window(GLOBALS->window_entry_c_1));
-		GLOBALS->entry_raise_timer = 0;
-		}
-        }
-
 #ifdef MAC_INTEGRATION
 if(GLOBALS->dnd_helper_quartz)
         {


### PR DESCRIPTION
This PR changes the implementation of `entrybox` to use a GTK dialog instead of a regular window.

I might have missed the reason `entrybox` was implemented this way, but using a dialog seems easier because it can be made modal without any additional code. The dialog is now also correctly positioned and the parent window gets dimmed to indicate that it is disabled.

Before:
![grafik](https://user-images.githubusercontent.com/226123/130694996-add3a221-cbb1-4a1d-a9fe-9201431485fd.png)

After:
![grafik](https://user-images.githubusercontent.com/226123/130695024-08fcba3d-2269-42ba-ba35-afd122433a4c.png)
