### PR TITLE
Handle global accelerators after widget keybindings

### DIFF
--- a/gtkwave3-gtk3/src/main.c
+++ b/gtkwave3-gtk3/src/main.c
@@ -662,6 +662,25 @@ if (gtk_selection_data_get_length(selection_data) > 0)
 	}
 }
 
+static gboolean window_key_press_event(GtkWidget *widget, GdkEventKey *event)
+{
+GtkWindow *window = GTK_WINDOW(widget);
+gboolean handled = FALSE;
+
+if (!handled)
+	handled = gtk_window_propagate_key_event(window, event);
+
+if (!handled)
+	handled = gtk_window_activate_key(window, event);
+
+if (!handled) {
+	GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(g_type_class_peek(GTK_TYPE_WIDGET));
+	handled = widget_class->key_press_event(widget, event);
+}
+
+return TRUE;
+}
+
 int main(int argc, char *argv[])
 {
 return(main_2(0, argc, argv));
@@ -2105,6 +2124,8 @@ if(!GLOBALS->socket_xid)
 
 	window_setup_dnd(GLOBALS->mainwindow);
 	g_signal_connect(XXX_GTK_OBJECT(GLOBALS->mainwindow), "drag-data-received", G_CALLBACK(window_drag_data_received), NULL);
+
+	g_signal_connect(XXX_GTK_OBJECT(GLOBALS->mainwindow), "key-press-event", G_CALLBACK(window_key_press_event), NULL);
 
 	gtk_widget_show(GLOBALS->mainwindow);
 	}

--- a/gtkwave3-gtk3/src/signal_list.c
+++ b/gtkwave3-gtk3/src/signal_list.c
@@ -753,7 +753,7 @@ static gboolean key_press_event(GtkWidget* widget, GdkEventKey* event)
                 } else {
                     set_cursor(signal_list, GLOBALS->traces.first);
                 }
-                break;
+                return GDK_EVENT_STOP;
 
             // Shift + Down: Move cursor down one trace
             case GDK_KEY_Down:
@@ -766,7 +766,7 @@ static gboolean key_press_event(GtkWidget* widget, GdkEventKey* event)
                 } else {
                     set_cursor(signal_list, GLOBALS->traces.first);
                 }
-                break;
+                return GDK_EVENT_STOP;
         }
     } else if (state == GW_CONTROL_MASK) {
         switch (event->keyval) {
@@ -776,7 +776,7 @@ static gboolean key_press_event(GtkWidget* widget, GdkEventKey* event)
 
                 signal_list->dirty = TRUE;
                 gtk_widget_queue_draw(widget);
-                break;
+                return GDK_EVENT_STOP;
         }
     } else if (state == (GDK_SHIFT_MASK | GW_CONTROL_MASK)) {
         switch (event->keyval) {
@@ -786,7 +786,7 @@ static gboolean key_press_event(GtkWidget* widget, GdkEventKey* event)
 
                 signal_list->dirty = TRUE;
                 gtk_widget_queue_draw(widget);
-                break;
+                return GDK_EVENT_STOP;
         }
     } else if (!state) {
         switch (event->keyval) {
@@ -794,41 +794,41 @@ static gboolean key_press_event(GtkWidget* widget, GdkEventKey* event)
             case GDK_KEY_Left:
             case GDK_KEY_KP_Left:
                 service_left_edge(NULL, NULL);
-                break;
+                return GDK_EVENT_STOP;
 
             // Right: Find next edge to the right
             case GDK_KEY_Right:
             case GDK_KEY_KP_Right:
                 service_right_edge(NULL, NULL);
-                break;
+                return GDK_EVENT_STOP;
 
             // Up: Scroll up by one trace
             case GDK_KEY_Up:
             case GDK_KEY_KP_Up:
                 scroll_up(signal_list, FALSE);
-                break;
+                return GDK_EVENT_STOP;
 
             // Down: Scroll down by one trace
             case GDK_KEY_Down:
             case GDK_KEY_KP_Down:
                 scroll_down(signal_list, FALSE);
-                break;
+                return GDK_EVENT_STOP;
 
             // Page Up: Scroll up by one page
             case GDK_KEY_Page_Up:
             case GDK_KEY_KP_Page_Up:
                 scroll_up(signal_list, TRUE);
-                break;
+                return GDK_EVENT_STOP;
 
             // Page Down: Scroll down by one page
             case GDK_KEY_Page_Down:
             case GDK_KEY_KP_Page_Down:
                 scroll_down(signal_list, TRUE);
-                break;
+                return GDK_EVENT_STOP;
         }
     }
 
-    return GDK_EVENT_STOP;
+    return GDK_EVENT_PROPAGATE;
 }
 
 static int y_to_drop_position(int y)


### PR DESCRIPTION
This PR should fix the problem with the keybindings.

As far as I can tell the previous solution to this problem was to manually check if the focus was inside the `filter_entry` and ignore the accelerators in this case.

The method used in this PR should be more generic. It changes the order the key press events are handled to give widget `key-press-event` handlers priority over global accelerators. The code is based on the default implementation in GTK: https://gitlab.gnome.org/GNOME/gtk/-/blob/gtk-3-24/gtk/gtkwindow.c#L8244