### PR TITLE
Export TCL commands in namespace

### DIFF
--- a/gtkwave3-gtk3/configure.ac
+++ b/gtkwave3-gtk3/configure.ac
@@ -154,11 +154,11 @@ if test "X$ETCL" = "Xyes" ; then
 		AC_SUBST(TCL_MINOR_VERSION)
 
 		if test "$TCL_MAJOR_VERSION" -lt "8" ; then
-			 AC_MSG_ERROR([Upgrade to at least Tcl version 8.4.])
+			 AC_MSG_ERROR([Upgrade to at least Tcl version 8.5.])
 		else
 			if test "$TCL_MAJOR_VERSION" -eq "8" ; then
-				if test "$TCL_MINOR_VERSION" -lt "4" ; then
-					 AC_MSG_ERROR([Upgrade to at least Tcl version 8.4.])
+				if test "$TCL_MINOR_VERSION" -lt "5" ; then
+					 AC_MSG_ERROR([Upgrade to at least Tcl version 8.5.])
 				fi
 			fi
 		fi

--- a/gtkwave3-gtk3/src/tcl_helper.c
+++ b/gtkwave3-gtk3/src/tcl_helper.c
@@ -2824,6 +2824,8 @@ int  gtkwaveInterpreterInit(Tcl_Interp *interp) {
 
   strcpy(commandName, "gtkwave::");
 
+  Tcl_Namespace *namespace = Tcl_CreateNamespace(interp, "gtkwave", NULL, NULL);
+
   ife = retrieve_menu_items_array(&num_menu_items);
   for(i=0;i<num_menu_items;i++)
     {
@@ -2851,6 +2853,8 @@ int  gtkwaveInterpreterInit(Tcl_Interp *interp) {
       Tcl_CreateObjCommand(interp, commandName,
 			   (Tcl_ObjCmdProc *)gtkwave_commands[i].func,
 			   (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);
+
+      Tcl_Export(interp, namespace, gtkwave_commands[i].cmdstr, 0);
     }
 
   declare_tclcb_variables(interp) ;


### PR DESCRIPTION
This PR exports the TCL commands in `gtkwave_commands` from the `gtkwave` namespace.

Without namespace: (This version is still supported after the changes in this PR)
```tcl
gtkwave::setMarker 128
gtkwave::setNamedMarker A 400 "Example Named Marker"
```

With namespace:
```tcl
namespace import gtkwave::*
setMarker 128
setNamedMarker A 400 "Example Named Marker"
```

This is especially useful to reduce typing when you use the `--wish` feature.