### PR TITLE
Also export TCL commands in GLOBALS->interp

### DIFF
--- a/gtkwave3-gtk3/src/tcl_helper.c
+++ b/gtkwave3-gtk3/src/tcl_helper.c
@@ -3018,6 +3018,8 @@ void make_tcl_interpreter(char *argv[])
 
   strcpy(commandName, "gtkwave::");
 
+  Tcl_Namespace *namespace = Tcl_CreateNamespace(GLOBALS->interp, "gtkwave", NULL, NULL);
+
   ife = retrieve_menu_items_array(&num_menu_items);
   for(i=0;i<num_menu_items;i++)
     {
@@ -3045,6 +3047,8 @@ void make_tcl_interpreter(char *argv[])
       Tcl_CreateObjCommand(GLOBALS->interp, commandName,
                 (Tcl_ObjCmdProc *)gtkwave_commands[i].func,
 			   (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);
+
+      Tcl_Export(GLOBALS->interp, namespace, gtkwave_commands[i].cmdstr, 0);
     }
 
   declare_tclcb_variables(GLOBALS->interp);


### PR DESCRIPTION
This is a followup to #93. I didn't realize there was a separate initialization for the script TCL interpreter. These changes make it possible to also use `namespace import gtkwave::*` in scripts.