### PR TITLE
Fix CI build after MSYS2 changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,10 @@ jobs:
         tries=0
         # Try building three times due to the arbitrary 'Bad address' error
         while [ $tries -lt 3 ]; do
-          makepkg-mingw --noconfirm --noprogressbar -sCLfc && break || tries=$((tries+1))
+          makepkg-mingw --noconfirm --noprogressbar -sCLfc && exit 0
+          tries=$((tries+1))
         done
+        exit 1
 
     - name: Install and create standalone package
       working-directory: ./MSYS2/gtk${{ matrix.gtk }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
           base-devel
           git
           mingw-w64-${{ matrix.target.arch }}-toolchain
+          mingw-w64-${{ matrix.target.arch }}-autotools
         msystem: ${{ matrix.target.msys2 }}
 
     - name: Build package


### PR DESCRIPTION
The autotools were recently removed from the MSYS2 `base-devel` package (https://www.msys2.org/news/#2021-12-22-ongoing-cleanup-of-the-base-devel-package-group) which causes the CI build to fail.