### PR TITLE
Use unbuffered I/O for FST on OpenBSD and FreeBSD

### DIFF
--- a/gtkwave3-gtk3/src/helpers/fst/fstapi.c
+++ b/gtkwave3-gtk3/src/helpers/fst/fstapi.c
@@ -140,6 +140,10 @@ void **JenkinsIns(void *base_i, const unsigned char *mem, uint32_t length, uint3
 #include <sys/sysctl.h>
 #endif
 
+#if defined(FST_MACOSX) || defined(__MINGW32__) || defined(__OpenBSD__) || defined(__FreeBSD__)
+#define FST_UNBUFFERED_IO
+#endif
+
 #ifdef __GNUC__
 /* Boolean expression more often true than false */
 #define FST_LIKELY(x) __builtin_expect(!!(x), 1)
@@ -4577,12 +4581,11 @@ if(sectype == FST_BL_ZWRAPPER)
                 if(!fcomp) { tmpfile_close(&fcomp, &xc->f_nam); return(0); }
                 }
 
-#if defined(FST_MACOSX)
+#if defined(FST_UNBUFFERED_IO)
         setvbuf(fcomp, (char *)NULL, _IONBF, 0);   /* keeps gzip from acting weird in tandem with fopen */
 #endif
 
 #ifdef __MINGW32__
-        setvbuf(fcomp, (char *)NULL, _IONBF, 0);   /* keeps gzip from acting weird in tandem with fopen */
         xc->filename_unpacked = hf;
 #else
         if(hf)
@@ -4880,7 +4883,7 @@ if((!nam)||(!(xc->f=fopen(nam, "rb"))))
         char *hf = (char *)calloc(1, flen + 6);
         int rc;
 
-#if defined(__MINGW32__) || defined(FST_MACOSX)
+#if defined(FST_UNBUFFERED_IO)
         setvbuf(xc->f, (char *)NULL, _IONBF, 0);   /* keeps gzip from acting weird in tandem with fopen */
 #endif
 

--- a/gtkwave3/src/helpers/fst/fstapi.c
+++ b/gtkwave3/src/helpers/fst/fstapi.c
@@ -140,6 +140,10 @@ void **JenkinsIns(void *base_i, const unsigned char *mem, uint32_t length, uint3
 #include <sys/sysctl.h>
 #endif
 
+#if defined(FST_MACOSX) || defined(__MINGW32__) || defined(__OpenBSD__) || defined(__FreeBSD__)
+#define FST_UNBUFFERED_IO
+#endif
+
 #ifdef __GNUC__
 /* Boolean expression more often true than false */
 #define FST_LIKELY(x) __builtin_expect(!!(x), 1)
@@ -4577,12 +4581,11 @@ if(sectype == FST_BL_ZWRAPPER)
                 if(!fcomp) { tmpfile_close(&fcomp, &xc->f_nam); return(0); }
                 }
 
-#if defined(FST_MACOSX)
+#if defined(FST_UNBUFFERED_IO)
         setvbuf(fcomp, (char *)NULL, _IONBF, 0);   /* keeps gzip from acting weird in tandem with fopen */
 #endif
 
 #ifdef __MINGW32__
-        setvbuf(fcomp, (char *)NULL, _IONBF, 0);   /* keeps gzip from acting weird in tandem with fopen */
         xc->filename_unpacked = hf;
 #else
         if(hf)
@@ -4880,7 +4883,7 @@ if((!nam)||(!(xc->f=fopen(nam, "rb"))))
         char *hf = (char *)calloc(1, flen + 6);
         int rc;
 
-#if defined(__MINGW32__) || defined(FST_MACOSX)
+#if defined(FST_UNBUFFERED_IO)
         setvbuf(xc->f, (char *)NULL, _IONBF, 0);   /* keeps gzip from acting weird in tandem with fopen */
 #endif
 


### PR DESCRIPTION
There's an existing fix in fstapi.c to set _IONBF on the FST file handle
on Windows and OS X.  This patch extends this to FreeBSD and OpenBSD
too, which both are otherwise unable to read FST files.