### PR TITLE
Fix compilation under macOS for Nix

### DIFF
--- a/gtkwave3-gtk3/configure.ac
+++ b/gtkwave3-gtk3/configure.ac
@@ -610,7 +610,10 @@ if test "X$GTK3" = "Xyes" ; then
         PKG_CHECK_MODULES(GTK, gtk+-3.0 >= 3.0.0)
         GTK_VER=`$PKG_CONFIG gtk+-3.0 --modversion`
 
-        _gdk_tgt=`$PKG_CONFIG --variable=target gdk-3.0`
+        # gdk-3.0 may have multiple targets e.g. "broadway quartz"
+        _gdk_tgts=`$PKG_CONFIG --variable=targets gdk-3.0`
+        for _gdk_tgt in $_gdk_tgts;
+        do
         if test "x$_gdk_tgt" = xquartz; then
            PKG_CHECK_MODULES(GTK_MAC, gtk-mac-integration >= 3.0.0)
            AC_SUBST(GTK_MAC_LIBS)
@@ -625,6 +628,7 @@ if test "X$GTK3" = "Xyes" ; then
            COCOA_GTK_LDFLAGS="-framework Cocoa -framework ApplicationServices"
            AC_SUBST(COCOA_GTK_LDFLAGS)
         fi
+        done
 
         if test x$with_gconf = xyes; then
           PKG_CHECK_MODULES(GCONF, gconf-2.0 >= 2.0)

--- a/gtkwave3-gtk3/src/main.c
+++ b/gtkwave3-gtk3/src/main.c
@@ -2144,10 +2144,15 @@ if(!GLOBALS->socket_xid)
 #ifdef WAVE_USE_XID
 	else
 	{
+#ifdef GDK_WINDOWING_X11
         GLOBALS->mainwindow = gtk_plug_new(GLOBALS->socket_xid);
         gtk_widget_show(GLOBALS->mainwindow);
 
         g_signal_connect(XXX_GTK_OBJECT(GLOBALS->mainwindow), "destroy",   /* formerly was "destroy" */G_CALLBACK(plug_destroy),"Plug destroy");
+#else
+	fprintf(stderr, "GTKWAVE | GtkPlug widget is unavailable\n");
+	exit(1);
+#endif
 	}
 #endif
 }

--- a/gtkwave3-gtk3/src/twinwave.c
+++ b/gtkwave3-gtk3/src/twinwave.c
@@ -33,7 +33,7 @@
 
 #include "debug.h"
 
-#ifdef __GTK_SOCKET_H__
+#if defined(__GTK_SOCKET_H__) && defined(GDK_WINDOWING_X11)
 static int use_embedded = 1;
 #else
 static int use_embedded = 0;
@@ -122,7 +122,7 @@ for(i=0;i<argc;i++)
 if(split_point < 0)
 	{
 	printf("Usage:\n------\n%s arglist1 separator arglist2\n\n"
-#ifdef __GTK_SOCKET_H__
+#if defined(__GTK_SOCKET_H__) && defined(GDK_WINDOWING_X11)
 		"The '+' between argument lists splits and creates one window.\n"
 		"The '++' between argument lists splits and creates two windows.\n"
 #else
@@ -152,7 +152,7 @@ if(GDK_IS_WAYLAND_DISPLAY(gdk_display_get_default()))
 	use_embedded = 0;
 	}
 #endif
-#ifdef __GTK_SOCKET_H__
+#if defined(__GTK_SOCKET_H__) && defined(GDK_WINDOWING_X11)
 	{
 	xsocket[0] = gtk_socket_new ();
 	xsocket[1] = gtk_socket_new ();
@@ -161,7 +161,7 @@ if(GDK_IS_WAYLAND_DISPLAY(gdk_display_get_default()))
 	}
 #endif
 
-#ifdef __GTK_SOCKET_H__
+#if defined(__GTK_SOCKET_H__) && defined(GDK_WINDOWING_X11)
 if(!twinwayland)
 g_signal_connect(XXX_GTK_OBJECT(xsocket[0]), "plug-removed", G_CALLBACK(plug_removed), NULL);
 #endif
@@ -184,7 +184,7 @@ vpan = gtk_vpaned_new ();
 gtk_widget_show (vpan);
 gtk_box_pack_start (GTK_BOX (main_vbox), vpan, TRUE, TRUE, 1);
 
-#ifdef __GTK_SOCKET_H__
+#if defined(__GTK_SOCKET_H__) && defined(GDK_WINDOWING_X11)
 if(!twinwayland)
 	{
 	gtk_paned_pack1 (GTK_PANED (vpan), xsocket[0], TRUE, FALSE);
@@ -223,7 +223,7 @@ if(hMapFile != NULL)
 				memset(&pi, 0, sizeof(PROCESS_INFORMATION));
 
 				sprintf(buf, "0+%08X", shmid);
-#if defined(MINGW_USE_XID) && defined(__GTK_SOCKET_H__)
+#if defined(MINGW_USE_XID) && defined(__GTK_SOCKET_H__) && defined(GDK_WINDOWING_X11)
 				sprintf(buf2, "%x", gtk_socket_get_id (GTK_SOCKET(xsocket[0])));
 #else
 				sprintf(buf2, "%x", 0);
@@ -294,7 +294,7 @@ if(hMapFile != NULL)
 				memset(&pi, 0, sizeof(PROCESS_INFORMATION));
 
 				sprintf(buf, "1+%08X", shmid);
-#if defined(MINGW_USE_XID) && defined(__GTK_SOCKET_H__)
+#if defined(MINGW_USE_XID) && defined(__GTK_SOCKET_H__) && defined(GDK_WINDOWING_X11)
 				sprintf(buf2, "%x", gtk_socket_get_id (GTK_SOCKET(xsocket[1])));
 #else
 				sprintf(buf2, "%x", 0);
@@ -444,7 +444,7 @@ if(shmid >=0)
 				sprintf(buf, "0+%08X", shmid);
 				if(use_embedded)
 					{
-#ifdef __GTK_SOCKET_H__
+#if defined(__GTK_SOCKET_H__) && defined(GDK_WINDOWING_X11)
 #ifdef MAC_INTEGRATION
 					sprintf(buf2, "%x", gtk_socket_get_id (GTK_SOCKET(xsocket[0])));
 #else
@@ -484,7 +484,7 @@ if(shmid >=0)
 			sprintf(buf, "1+%08X", shmid);
 			if(use_embedded)
 				{
-#ifdef __GTK_SOCKET_H__
+#if defined(__GTK_SOCKET_H__) && defined(GDK_WINDOWING_X11)
 #ifdef MAC_INTEGRATION
 				sprintf(buf2, "%x", gtk_socket_get_id (GTK_SOCKET(xsocket[1])));
 #else


### PR DESCRIPTION
I am porting gtkwave to build in macOS, and faced the following two issues.

First issue:

The GTK+3 built by Nix targets `broadway quartz` instead of only `quartz`, thus the target check is wrong:

```bash
_gdk_tgt=`$PKG_CONFIG --variable=target gdk-3.0`
if test "x$_gdk_tgt" = xquartz; then
```

```shell
$ pkg-config --variable=target gdk-3.0

$ pkg-config --variable=targets gdk-3.0
broadway quartz
```

The variable name is renamed to `targets` in newer version of GTK+3, and I modified the script to look up `quartz` in a loop.

Second issue:

The code uses GtkPlug and GtkSocket widgets. They are only available when GTK+3 is targeted to X11, according to [gtk+3 docs](https://docs.gtk.org/gtk3/class.Plug.html):

     The GtkPlug and GtkSocket widgets are only available when GTK+ is compiled for the X11 platform and GDK_WINDOWING_X11 is defined. They can only be used on a GdkX11Display. To use GtkPlug and GtkSocket, you need to include the gtk/gtkx.h header.

I added the check for `GDK_WINDOWING_X11` macro along with `__GTK_SOCKET_H__ `.