### PR TITLE
Clamp drop position to number of visible traces

### DIFF
--- a/gtkwave3-gtk3/src/signal_list.c
+++ b/gtkwave3-gtk3/src/signal_list.c
@@ -843,7 +843,7 @@ static int y_to_drop_position(int y)
 
     // Limit position to the total number of traces.
     // Dropping an item on the empty space after the last appends the item at the end of the list.
-    position = CLAMP(position, 0, GLOBALS->traces.total);
+    position = CLAMP(position, 0, GLOBALS->traces.visible);
 
     return position;
 }

--- a/gtkwave4/src/signal_list.c
+++ b/gtkwave4/src/signal_list.c
@@ -801,7 +801,7 @@ static int y_to_drop_position(int y)
 
     // Limit position to the total number of traces.
     // Dropping an item on the empty space after the last appends the item at the end of the list.
-    position = CLAMP(position, 0, GLOBALS->traces.total);
+    position = CLAMP(position, 0, GLOBALS->traces.visible);
 
     return position;
 }


### PR DESCRIPTION
This PR fixes a bug in `signal_list.c` where the drop highlight position is clamped to the total number of traces instead of the visible number of traces. This caused the highlight to potentially be draw below the last trace in the list, if closed groups were present.