### PR TITLE
FST loading fix for signals containing inner '[' characters

### DIFF
--- a/gtkwave3-gtk3/src/fst.c
+++ b/gtkwave3-gtk3/src/fst.c
@@ -146,7 +146,7 @@ static struct fstHier *extractNextVar(void *xc, int *msb, int *lsb, char **nam, 
 {
 struct fstHier *h;
 const char *pnts;
-char *pnt, *pntd, *lb_last = NULL, *col_last = NULL; /* *rb_last = NULL; */ /* scan-build : unused */
+char *pnt, *pntd, *lb_last = NULL, *col_last = NULL, *rb_last = NULL;
 int acc;
 char *s;
 unsigned char ttype;
@@ -217,15 +217,23 @@ while((h = fstReaderIterateHier(xc)))
 				{
 				if(*pnts != ' ')
 					{
-					if(*pnts == '[') { lb_last = pntd; col_last = NULL; }
-					else if(*pnts == ':') { col_last = pntd; }
-					/* else if(*pnts == ']') { rb_last = pntd; } */ /* scan-build : unused */
+					if(*pnts == '[') { lb_last = pntd; col_last = NULL; rb_last = NULL; }
+					else if(*pnts == ':' && lb_last != NULL && col_last == NULL && rb_last == NULL) { col_last = pntd; }
+					else if(*pnts == ']' && lb_last != NULL && rb_last == NULL) { rb_last = pntd; }
+					else if(lb_last != NULL && rb_last == NULL && (isdigit((int)(unsigned char)*pnts) || (*pnts == '-'))) { }
+					else { lb_last = NULL; col_last = NULL; rb_last = NULL; }
 
 					*(pntd++) = *pnts;
 					}
 				pnts++;
 				}
 			*pntd = 0; *namlen = pntd - s;
+
+			if(!rb_last)
+				{
+				col_last = NULL;
+				lb_last = NULL;
+				}
 
 			if(!lb_last)
 				{

--- a/gtkwave3/src/fst.c
+++ b/gtkwave3/src/fst.c
@@ -148,7 +148,7 @@ static struct fstHier *extractNextVar(void *xc, int *msb, int *lsb, char **nam, 
 {
 struct fstHier *h;
 const char *pnts;
-char *pnt, *pntd, *lb_last = NULL, *col_last = NULL; /* *rb_last = NULL; */ /* scan-build : unused */
+char *pnt, *pntd, *lb_last = NULL, *col_last = NULL, *rb_last = NULL;
 int acc;
 char *s;
 unsigned char ttype;
@@ -219,15 +219,23 @@ while((h = fstReaderIterateHier(xc)))
 				{
 				if(*pnts != ' ')
 					{
-					if(*pnts == '[') { lb_last = pntd; col_last = NULL; }
-					else if(*pnts == ':') { col_last = pntd; }
-					/* else if(*pnts == ']') { rb_last = pntd; } */ /* scan-build : unused */
+					if(*pnts == '[') { lb_last = pntd; col_last = NULL; rb_last = NULL; }
+					else if(*pnts == ':' && lb_last != NULL && col_last == NULL && rb_last == NULL) { col_last = pntd; }
+					else if(*pnts == ']' && lb_last != NULL && rb_last == NULL) { rb_last = pntd; }
+					else if(lb_last != NULL && rb_last == NULL && (isdigit((int)(unsigned char)*pnts) || (*pnts == '-'))) { }
+					else { lb_last = NULL; col_last = NULL; rb_last = NULL; }
 
 					*(pntd++) = *pnts;
 					}
 				pnts++;
 				}
 			*pntd = 0; *namlen = pntd - s;
+
+			if(!rb_last)
+				{
+				col_last = NULL;
+				lb_last = NULL;
+				}
 
 			if(!lb_last)
 				{

--- a/gtkwave4/src/fst.c
+++ b/gtkwave4/src/fst.c
@@ -146,7 +146,7 @@ static struct fstHier *extractNextVar(void *xc, int *msb, int *lsb, char **nam, 
 {
 struct fstHier *h;
 const char *pnts;
-char *pnt, *pntd, *lb_last = NULL, *col_last = NULL; /* *rb_last = NULL; */ /* scan-build : unused */
+char *pnt, *pntd, *lb_last = NULL, *col_last = NULL, *rb_last = NULL;
 int acc;
 char *s;
 unsigned char ttype;
@@ -217,15 +217,23 @@ while((h = fstReaderIterateHier(xc)))
 				{
 				if(*pnts != ' ')
 					{
-					if(*pnts == '[') { lb_last = pntd; col_last = NULL; }
-					else if(*pnts == ':') { col_last = pntd; }
-					/* else if(*pnts == ']') { rb_last = pntd; } */ /* scan-build : unused */
+					if(*pnts == '[') { lb_last = pntd; col_last = NULL; rb_last = NULL; }
+					else if(*pnts == ':' && lb_last != NULL && col_last == NULL && rb_last == NULL) { col_last = pntd; }
+					else if(*pnts == ']' && lb_last != NULL && rb_last == NULL) { rb_last = pntd; }
+					else if(lb_last != NULL && rb_last == NULL && (isdigit((int)(unsigned char)*pnts) || (*pnts == '-'))) { }
+					else { lb_last = NULL; col_last = NULL; rb_last = NULL; }
 
 					*(pntd++) = *pnts;
 					}
 				pnts++;
 				}
 			*pntd = 0; *namlen = pntd - s;
+
+			if(!rb_last)
+				{
+				col_last = NULL;
+				lb_last = NULL;
+				}
 
 			if(!lb_last)
 				{


### PR DESCRIPTION
The FST loader looks for signal names ending with [msb:lsb] or [bit] and if found parses that and removes it from the signal name. Previously it would always remove everything starting from the last '[' character, even if it did not match either pattern, e.g. with non-numeric text within brackets or with brackets in the middle of the signal name.

This patch changes the parsing code to a) check for the final closing ']' as last character in the name and b) check that no unexpected characters appear between the brackets. Only if the checks pass is the suffix parsed and removed from the signal name.

I have some use cases with yosys where I end up with multiple such signals that only differ in the part following the last '[', i.e. "foo[bar]" and "foo[baz]" which makes this particularly bad, as there is no way to identify these signals when the part in brackets is removed.