### PR TITLE
Don't crash when loading FST string sigs

### DIFF
--- a/gtkwave3-gtk3/src/fst.c
+++ b/gtkwave3-gtk3/src/fst.c
@@ -1528,7 +1528,7 @@ else	/* string */
 		{
 		if((!strcmp(l2e->histent_curr->v.h_vector, (const char *)value)) && (!GLOBALS->vcd_preserve_glitches))
 			{
-			free(s);
+			free_2(s);
 			return;
 			}
 		}

--- a/gtkwave3/src/fst.c
+++ b/gtkwave3/src/fst.c
@@ -1530,7 +1530,7 @@ else	/* string */
 		{
 		if((!strcmp(l2e->histent_curr->v.h_vector, (const char *)value)) && (!GLOBALS->vcd_preserve_glitches))
 			{
-			free(s);
+			free_2(s);
 			return;
 			}
 		}

--- a/gtkwave4/src/fst.c
+++ b/gtkwave4/src/fst.c
@@ -1528,7 +1528,7 @@ else	/* string */
 		{
 		if((!strcmp(l2e->histent_curr->v.h_vector, (const char *)value)) && (!GLOBALS->vcd_preserve_glitches))
 			{
-			free(s);
+			free_2(s);
 			return;
 			}
 		}


### PR DESCRIPTION
A mismatched malloc_2/free_2 was causing memory
corruption when loading FST string signals. Change free to free_2 to free the correct address and not crash on these.