### PR TITLE
Improve bundle directory detection.

### DIFF
--- a/gtkwave3-gtk3/contrib/bundle_for_osx/launcher.sh
+++ b/gtkwave3-gtk3/contrib/bundle_for_osx/launcher.sh
@@ -10,11 +10,8 @@ else
     EXEC=exec
 fi
 
-name="`basename $0`"
-tmp="`pwd`/$0"
-tmp=`dirname "$tmp"`
-tmp=`dirname "$tmp"`
-bundle=`dirname "$tmp"`
+name=$(basename $0)
+bundle="$(cd `dirname $0`; cd ../..; pwd)"
 bundle_contents="$bundle"/Contents
 bundle_res="$bundle_contents"/Resources
 bundle_lib="$bundle_res"/lib

--- a/gtkwave3/contrib/bundle_for_osx/launcher.sh
+++ b/gtkwave3/contrib/bundle_for_osx/launcher.sh
@@ -10,11 +10,8 @@ else
     EXEC=exec
 fi
 
-name="`basename $0`"
-tmp="`pwd`/$0"
-tmp=`dirname "$tmp"`
-tmp=`dirname "$tmp"`
-bundle=`dirname "$tmp"`
+name=$(basename $0)
+bundle="$(cd `dirname $0`; cd ../..; pwd)"
 bundle_contents="$bundle"/Contents
 bundle_res="$bundle_contents"/Resources
 bundle_lib="$bundle_res"/lib

--- a/gtkwave4/contrib/bundle_for_osx/launcher.sh
+++ b/gtkwave4/contrib/bundle_for_osx/launcher.sh
@@ -10,11 +10,8 @@ else
     EXEC=exec
 fi
 
-name="`basename $0`"
-tmp="`pwd`/$0"
-tmp=`dirname "$tmp"`
-tmp=`dirname "$tmp"`
-bundle=`dirname "$tmp"`
+name=$(basename $0)
+bundle="$(cd `dirname $0`; cd ../..; pwd)"
 bundle_contents="$bundle"/Contents
 bundle_res="$bundle_contents"/Resources
 bundle_lib="$bundle_res"/lib


### PR DESCRIPTION
Now works no matter what the current directory is allowing the binary to be run out of the application from the command line.

Note that I have only tested this by editing the script in the prebuilt application downloaded from https://sourceforge.net/projects/gtkwave/files/gtkwave-3.3.107-osx-app/ as I don't have the app build environment setup.
