### PR TITLE
Disable stdio buffering when accessing FST files on NetBSD

### DIFF
--- a/gtkwave3-gtk3/src/helpers/fst/fstapi.c
+++ b/gtkwave3-gtk3/src/helpers/fst/fstapi.c
@@ -140,7 +140,7 @@ void **JenkinsIns(void *base_i, const unsigned char *mem, uint32_t length, uint3
 #include <sys/sysctl.h>
 #endif
 
-#if defined(FST_MACOSX) || defined(__MINGW32__) || defined(__OpenBSD__) || defined(__FreeBSD__)
+#if defined(FST_MACOSX) || defined(__MINGW32__) || defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__NetBSD__)
 #define FST_UNBUFFERED_IO
 #endif
 

--- a/gtkwave3/src/helpers/fst/fstapi.c
+++ b/gtkwave3/src/helpers/fst/fstapi.c
@@ -140,7 +140,7 @@ void **JenkinsIns(void *base_i, const unsigned char *mem, uint32_t length, uint3
 #include <sys/sysctl.h>
 #endif
 
-#if defined(FST_MACOSX) || defined(__MINGW32__) || defined(__OpenBSD__) || defined(__FreeBSD__)
+#if defined(FST_MACOSX) || defined(__MINGW32__) || defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__NetBSD__)
 #define FST_UNBUFFERED_IO
 #endif
 

--- a/gtkwave4/src/helpers/fst/fstapi.c
+++ b/gtkwave4/src/helpers/fst/fstapi.c
@@ -140,7 +140,7 @@ void **JenkinsIns(void *base_i, const unsigned char *mem, uint32_t length, uint3
 #include <sys/sysctl.h>
 #endif
 
-#if defined(FST_MACOSX) || defined(__MINGW32__) || defined(__OpenBSD__) || defined(__FreeBSD__)
+#if defined(FST_MACOSX) || defined(__MINGW32__) || defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__NetBSD__)
 #define FST_UNBUFFERED_IO
 #endif
 


### PR DESCRIPTION
This is the same as OpenBSD and FreeBSD.

I tested the code in gtkwave3, gtkwave3-gtk3 and gtkwave4. I could only test that my change compiled in gtkwave4, but I was able to run the other versions of gtkwave and confirm that I can open FST files on NetBSD.
