### PR TITLE
Only include Wayland headers when GDK has Wayland support

### DIFF
--- a/gtkwave3-gtk3/src/gtk23compat.h
+++ b/gtkwave3-gtk3/src/gtk23compat.h
@@ -8,7 +8,8 @@
 #endif
 
 #if GTK_CHECK_VERSION(3,22,26)
-#if !defined(__MINGW32__) && !defined(MAC_INTEGRATION)
+#if !defined(__MINGW32__) && !defined(MAC_INTEGRATION) \
+  && defined(GDK_WINDOWING_WAYLAND)
 #include <gdk/gdkwayland.h>
 #endif
 #endif

--- a/gtkwave3-gtk3/src/twinwave.c
+++ b/gtkwave3-gtk3/src/twinwave.c
@@ -19,7 +19,7 @@
 #include <gtk/gtkx.h>
 #endif
 #if GTK_CHECK_VERSION(3,22,26)
-#if !defined(MAC_INTEGRATION)
+#if !defined(MAC_INTEGRATION) && defined(GDK_WINDOWING_WAYLAND)
 #include <gdk/gdkwayland.h>
 #endif
 #endif

--- a/gtkwave4/src/gtk23compat.h
+++ b/gtkwave4/src/gtk23compat.h
@@ -8,7 +8,8 @@
 #endif
 
 #if GTK_CHECK_VERSION(3,22,26)
-#if !defined(__MINGW32__) && !defined(MAC_INTEGRATION)
+#if !defined(__MINGW32__) && !defined(MAC_INTEGRATION) \
+  && defined(GDK_WINDOWING_WAYLAND)
 #include <gdk/gdkwayland.h>
 #endif
 #endif

--- a/gtkwave4/src/twinwave.c
+++ b/gtkwave4/src/twinwave.c
@@ -19,7 +19,7 @@
 #include <gtk/gtkx.h>
 #endif
 #if GTK_CHECK_VERSION(3,22,26)
-#if !defined(MAC_INTEGRATION)
+#if !defined(MAC_INTEGRATION) && defined(GDK_WINDOWING_WAYLAND)
 #include <gdk/gdkwayland.h>
 #endif
 #endif


### PR DESCRIPTION
Don't try to include gdk/gdkwayland.h unless the GDK backend declares support for Wayland. This allows Gtkwave to be built with Gtk versions
>= 3.22.26 without requiring Wayland support.