### PR TITLE
Fix use_multi_state condition in vzt_write.c

### DIFF
--- a/gtkwave3-gtk3/src/helpers/vzt_write.c
+++ b/gtkwave3-gtk3/src/helpers/vzt_write.c
@@ -1259,7 +1259,9 @@ if(!lt->timegranule)
 		struct vzt_wr_symbol *s = lt->sorted_facs[j];
 		for(i=0;i<s->len;i++)
 			{
-			lt->use_multi_state |= s->chgx[i];
+			if (s->chgx[i] != 0) {
+				lt->use_multi_state = 1;
+			}
 			t = vzt_wr_dsvzt_splay(s->chgx[i], t);
 			if(!vzt_wr_dsvzt_success)
 				{
@@ -1308,7 +1310,9 @@ if(!lt->timegranule)
 		for(i=0;i<s->len;i++)
 			{
 			t = s->prevx[i]->child;
-			lt->use_multi_state |= s->chgx[i];
+			if (s->chgx[i] != 0) {
+				lt->use_multi_state = 1;
+			}
 			t = vzt_wr_dsvzt_splay(s->chgx[i], t);
 			if(!vzt_wr_dsvzt_success)
 				{

--- a/gtkwave4/src/helpers/vzt_write.c
+++ b/gtkwave4/src/helpers/vzt_write.c
@@ -1259,7 +1259,9 @@ if(!lt->timegranule)
 		struct vzt_wr_symbol *s = lt->sorted_facs[j];
 		for(i=0;i<s->len;i++)
 			{
-			lt->use_multi_state |= s->chgx[i];
+			if (s->chgx[i] != 0) {
+				lt->use_multi_state = 1;
+			}
 			t = vzt_wr_dsvzt_splay(s->chgx[i], t);
 			if(!vzt_wr_dsvzt_success)
 				{
@@ -1308,7 +1310,9 @@ if(!lt->timegranule)
 		for(i=0;i<s->len;i++)
 			{
 			t = s->prevx[i]->child;
-			lt->use_multi_state |= s->chgx[i];
+			if (s->chgx[i] != 0) {
+				lt->use_multi_state = 1;
+			}
 			t = vzt_wr_dsvzt_splay(s->chgx[i], t);
 			if(!vzt_wr_dsvzt_success)
 				{


### PR DESCRIPTION
The `use_multi_state` flag in `vzt_write.c` wasn't set in some cases, which caused `x` and `z` values to be written as incorrect `0`s and `1`s.  `use_multi_state` is a 1 bit unsigned integer and was only set if the LSB  of `s->chgx[i]` was set.