### PR TITLE
Fix reading strings at the start of a VZT file

### DIFF
--- a/gtkwave3-gtk3/src/helpers/vzt_read.c
+++ b/gtkwave3-gtk3/src/helpers/vzt_read.c
@@ -782,7 +782,7 @@ do_vch:				if(!(lt->flags[idx] & (VZT_RD_SYM_F_DOUBLE|VZT_RD_SYM_F_STRING)))
 					else
 						{
 						unsigned int spnt=vzt_rd_make_sindex(pnt);
-						char *msg = ((!i)&(!b->prev)) ? "UNDEF" : b->sindex[spnt];
+						char *msg = ((!i)&&(b->prev)) ? "UNDEF" : b->sindex[spnt];
 						lt->value_change_callback(&lt, &b->times[i], &idx, &msg);
 						}
 					}
@@ -857,7 +857,7 @@ do_vch_0:		if(!(lt->flags[idx] & (VZT_RD_SYM_F_DOUBLE|VZT_RD_SYM_F_STRING)))
 				else
 					{
 					unsigned int spnt=vzt_rd_make_sindex(pnt);
-					char *msg = ((!i)&(!b->prev)) ? "UNDEF" : b->sindex[spnt];
+					char *msg = ((!i)&&(b->prev)) ? "UNDEF" : b->sindex[spnt];
 					lt->value_change_callback(&lt, &b->times[i], &idx, &msg);
 					}
 				}
@@ -908,7 +908,7 @@ for(i = 1; i < b->num_time_ticks; i++)
 				else
 					{
 					unsigned int spnt=vzt_rd_make_sindex(pnt);
-					char *msg = ((!i)&(!b->prev)) ? "UNDEF" : b->sindex[spnt];
+					char *msg = ((!i)&&(b->prev)) ? "UNDEF" : b->sindex[spnt];
 					lt->value_change_callback(&lt, &b->times[i], &idx, &msg);
 					}
 				}

--- a/gtkwave4/src/helpers/vzt_read.c
+++ b/gtkwave4/src/helpers/vzt_read.c
@@ -782,7 +782,7 @@ do_vch:				if(!(lt->flags[idx] & (VZT_RD_SYM_F_DOUBLE|VZT_RD_SYM_F_STRING)))
 					else
 						{
 						unsigned int spnt=vzt_rd_make_sindex(pnt);
-						char *msg = ((!i)&(!b->prev)) ? "UNDEF" : b->sindex[spnt];
+						char *msg = ((!i)&&(b->prev)) ? "UNDEF" : b->sindex[spnt];
 						lt->value_change_callback(&lt, &b->times[i], &idx, &msg);
 						}
 					}
@@ -857,7 +857,7 @@ do_vch_0:		if(!(lt->flags[idx] & (VZT_RD_SYM_F_DOUBLE|VZT_RD_SYM_F_STRING)))
 				else
 					{
 					unsigned int spnt=vzt_rd_make_sindex(pnt);
-					char *msg = ((!i)&(!b->prev)) ? "UNDEF" : b->sindex[spnt];
+					char *msg = ((!i)&&(b->prev)) ? "UNDEF" : b->sindex[spnt];
 					lt->value_change_callback(&lt, &b->times[i], &idx, &msg);
 					}
 				}
@@ -908,7 +908,7 @@ for(i = 1; i < b->num_time_ticks; i++)
 				else
 					{
 					unsigned int spnt=vzt_rd_make_sindex(pnt);
-					char *msg = ((!i)&(!b->prev)) ? "UNDEF" : b->sindex[spnt];
+					char *msg = ((!i)&&(b->prev)) ? "UNDEF" : b->sindex[spnt];
 					lt->value_change_callback(&lt, &b->times[i], &idx, &msg);
 					}
 				}


### PR DESCRIPTION
If a string variable in a VZT file contains a value change at the beginning of the file it is displayed as `UNDEF` instead of the correct value. This PR changes the condition, which determines if `UNDEF` should be used. I'm not 100% sure that the new condition is correct, but it matches other similar conditions in the file and seems to work.

I've attached a test VZT file, if you want to replicate the problem: [vzt_with_strings.zip](https://github.com/gtkwave/gtkwave/files/10532356/vzt_with_strings.zip)
