### PR TITLE
When using Sleep() on windows this API takes milliseconds

### DIFF
--- a/gtkwave3-gtk3/src/globals.c
+++ b/gtkwave3-gtk3/src/globals.c
@@ -51,7 +51,7 @@
 #include "fsdb_wrapper_api.h"
 
 #ifdef __MINGW32__
-#define sleep(x) Sleep(x)
+#define sleep(x) Sleep(x * 1000)
 #endif
 
 #if !defined __MINGW32__

--- a/gtkwave3/src/globals.c
+++ b/gtkwave3/src/globals.c
@@ -50,7 +50,7 @@
 #include "fsdb_wrapper_api.h"
 
 #ifdef __MINGW32__
-#define sleep(x) Sleep(x)
+#define sleep(x) Sleep(x * 1000)
 #endif
 
 #if !defined __MINGW32__ && !defined _MSC_VER

--- a/gtkwave4/src/globals.c
+++ b/gtkwave4/src/globals.c
@@ -51,7 +51,7 @@
 #include "fsdb_wrapper_api.h"
 
 #ifdef __MINGW32__
-#define sleep(x) Sleep(x)
+#define sleep(x) Sleep(x * 1000)
 #endif
 
 #if !defined __MINGW32__


### PR DESCRIPTION
The gtkwave function caller is expecting to pass in the number of seconds.

This was causing MSYS2 builds to end up in a tight loop causing UI blocking and the cursor to be always busy.  This can easily be trigged during a reload and the underlying file or directory was removed, or the VCD is being rewritten by another process causing Win32 file locking.  Once triggered the only reliable exit is to kill the process.

Another consideration is to reevaluate the historical reason why this #ifdef exists at all, as a quick test compile today inside MSYS2 mingw-w64-x86_64-gcc shows that the POSIX sleep(unsigned int seconds) is implemented as expected by the gtkwave caller.

Reference:
https://learn.microsoft.com/en-us/search/?terms=sleep&scope=Desktop https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-sleep