### PR TITLE
MSYS2 build.yml: install mingw-w64-${{ matrix.target.arch }}-gperf

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
           git
           mingw-w64-${{ matrix.target.arch }}-toolchain
           mingw-w64-${{ matrix.target.arch }}-autotools
+          mingw-w64-${{ matrix.target.arch }}-gperf
         msystem: ${{ matrix.target.msys2 }}
 
     - name: Build package


### PR DESCRIPTION
This should fix the build error on MSYS2:
  configure: error: Couldn't find a usable gperf program.
  Please install gperf which is available from
  ftp://ftp.gnu.org/pub/gnu/gperf/

  ==> ERROR: A failure occurred in build().

Related links:
  https://packages.msys2.org/base/mingw-w64-gperf