### PR TITLE
Use MapViewOfFileEx for mmap on Windows

### DIFF
--- a/gtkwave3-gtk3/src/helpers/fst/fstapi.c
+++ b/gtkwave3-gtk3/src/helpers/fst/fstapi.c
@@ -58,6 +58,7 @@
 #endif
 
 #ifdef __MINGW32__
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 
@@ -334,26 +335,22 @@ return(NULL);
 /*
  * mmap compatibility
  */
-#if defined __CYGWIN__ || defined __MINGW32__
+#if defined __MINGW32__
 #include <limits.h>
 #define fstMmap(__addr,__len,__prot,__flags,__fd,__off) fstMmap2((__len), (__fd), (__off))
-#define fstMunmap(__addr,__len)                         free(__addr)
+#define fstMunmap(__addr,__len)                         UnmapViewOfFile((LPCVOID)__addr)
 
 static void *fstMmap2(size_t __len, int __fd, fst_off_t __off)
 {
-(void)__off;
+HANDLE handle = CreateFileMapping((HANDLE)_get_osfhandle(__fd), NULL,
+				  PAGE_READWRITE, (DWORD)(__len >> 32),
+				  (DWORD)__len, NULL);
+if (!handle) { return NULL; }
 
-unsigned char *pnt = (unsigned char *)malloc(__len);
-fst_off_t cur_offs = lseek(__fd, 0, SEEK_CUR);
-size_t i;
-
-lseek(__fd, 0, SEEK_SET);
-for(i=0;i<__len;i+=SSIZE_MAX)
-        {
-        read(__fd, pnt + i, ((__len - i) >= SSIZE_MAX) ? SSIZE_MAX : (__len - i));
-        }
-lseek(__fd, cur_offs, SEEK_SET);
-return(pnt);
+void *ptr = MapViewOfFileEx(handle, FILE_MAP_READ | FILE_MAP_WRITE,
+			    0, (DWORD)__off, (SIZE_T)__len, (LPVOID)NULL);
+CloseHandle(handle);
+return ptr;
 }
 #else
 #include <sys/mman.h>
@@ -984,14 +981,26 @@ fflush(xc->handle);
  */
 static void fstWriterMmapSanity(void *pnt, const char *file, int line, const char *usage)
 {
-#if !defined(__CYGWIN__) && !defined(__MINGW32__)
-if(pnt == MAP_FAILED)
+if(pnt == NULL
+#ifdef MAP_FAILED
+   || pnt == MAP_FAILED
+#endif
+  )
 	{
 	fprintf(stderr, "fstMmap() assigned to %s failed: errno: %d, file %s, line %d.\n", usage, errno, file, line);
+#if !defined(__MINGW32__)
 	perror("Why");
+#else
+	LPSTR mbuf = NULL;
+	FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM
+		      | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, GetLastError(),
+		      MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+		      (LPSTR)&mbuf, 0, NULL);
+	fprintf(stderr, "%s", mbuf);
+	LocalFree(mbuf);
+#endif
 	pnt = NULL;
 	}
-#endif
 }
 
 
@@ -1037,33 +1046,10 @@ if(!xc->curval_mem)
 
 static void fstDestroyMmaps(struct fstWriterContext *xc, int is_closing)
 {
-#if !defined __CYGWIN__ && !defined __MINGW32__
 (void)is_closing;
-#endif
 
 fstMunmap(xc->valpos_mem, xc->maxhandle * 4 * sizeof(uint32_t));
 xc->valpos_mem = NULL;
-
-#if defined __CYGWIN__ || defined __MINGW32__
-if(xc->curval_mem)
-        {
-        if(!is_closing) /* need to flush out for next emulated mmap() read */
-                {
-                unsigned char *pnt = xc->curval_mem;
-                int __fd = fileno(xc->curval_handle);
-                fst_off_t cur_offs = lseek(__fd, 0, SEEK_CUR);
-                size_t i;
-                size_t __len = xc->maxvalpos;
-
-                lseek(__fd, 0, SEEK_SET);
-                for(i=0;i<__len;i+=SSIZE_MAX)
-                        {
-                        write(__fd, pnt + i, ((__len - i) >= SSIZE_MAX) ? SSIZE_MAX : (__len - i));
-                        }
-                lseek(__fd, cur_offs, SEEK_SET);
-                }
-        }
-#endif
 
 fstMunmap(xc->curval_mem, xc->maxvalpos);
 xc->curval_mem = NULL;

--- a/gtkwave3/src/helpers/fst/fstapi.c
+++ b/gtkwave3/src/helpers/fst/fstapi.c
@@ -58,6 +58,7 @@
 #endif
 
 #ifdef __MINGW32__
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 
@@ -334,26 +335,22 @@ return(NULL);
 /*
  * mmap compatibility
  */
-#if defined __CYGWIN__ || defined __MINGW32__
+#if defined __MINGW32__
 #include <limits.h>
 #define fstMmap(__addr,__len,__prot,__flags,__fd,__off) fstMmap2((__len), (__fd), (__off))
-#define fstMunmap(__addr,__len)                         free(__addr)
+#define fstMunmap(__addr,__len)                         UnmapViewOfFile((LPCVOID)__addr)
 
 static void *fstMmap2(size_t __len, int __fd, fst_off_t __off)
 {
-(void)__off;
+HANDLE handle = CreateFileMapping((HANDLE)_get_osfhandle(__fd), NULL,
+				  PAGE_READWRITE, (DWORD)(__len >> 32),
+				  (DWORD)__len, NULL);
+if (!handle) { return NULL; }
 
-unsigned char *pnt = (unsigned char *)malloc(__len);
-fst_off_t cur_offs = lseek(__fd, 0, SEEK_CUR);
-size_t i;
-
-lseek(__fd, 0, SEEK_SET);
-for(i=0;i<__len;i+=SSIZE_MAX)
-        {
-        read(__fd, pnt + i, ((__len - i) >= SSIZE_MAX) ? SSIZE_MAX : (__len - i));
-        }
-lseek(__fd, cur_offs, SEEK_SET);
-return(pnt);
+void *ptr = MapViewOfFileEx(handle, FILE_MAP_READ | FILE_MAP_WRITE,
+			    0, (DWORD)__off, (SIZE_T)__len, (LPVOID)NULL);
+CloseHandle(handle);
+return ptr;
 }
 #else
 #include <sys/mman.h>
@@ -984,14 +981,26 @@ fflush(xc->handle);
  */
 static void fstWriterMmapSanity(void *pnt, const char *file, int line, const char *usage)
 {
-#if !defined(__CYGWIN__) && !defined(__MINGW32__)
-if(pnt == MAP_FAILED)
+if(pnt == NULL
+#ifdef MAP_FAILED
+   || pnt == MAP_FAILED
+#endif
+  )
 	{
 	fprintf(stderr, "fstMmap() assigned to %s failed: errno: %d, file %s, line %d.\n", usage, errno, file, line);
+#if !defined(__MINGW32__)
 	perror("Why");
+#else
+	LPSTR mbuf = NULL;
+	FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM
+		      | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, GetLastError(),
+		      MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+		      (LPSTR)&mbuf, 0, NULL);
+	fprintf(stderr, "%s", mbuf);
+	LocalFree(mbuf);
+#endif
 	pnt = NULL;
 	}
-#endif
 }
 
 
@@ -1037,33 +1046,10 @@ if(!xc->curval_mem)
 
 static void fstDestroyMmaps(struct fstWriterContext *xc, int is_closing)
 {
-#if !defined __CYGWIN__ && !defined __MINGW32__
 (void)is_closing;
-#endif
 
 fstMunmap(xc->valpos_mem, xc->maxhandle * 4 * sizeof(uint32_t));
 xc->valpos_mem = NULL;
-
-#if defined __CYGWIN__ || defined __MINGW32__
-if(xc->curval_mem)
-        {
-        if(!is_closing) /* need to flush out for next emulated mmap() read */
-                {
-                unsigned char *pnt = xc->curval_mem;
-                int __fd = fileno(xc->curval_handle);
-                fst_off_t cur_offs = lseek(__fd, 0, SEEK_CUR);
-                size_t i;
-                size_t __len = xc->maxvalpos;
-
-                lseek(__fd, 0, SEEK_SET);
-                for(i=0;i<__len;i+=SSIZE_MAX)
-                        {
-                        write(__fd, pnt + i, ((__len - i) >= SSIZE_MAX) ? SSIZE_MAX : (__len - i));
-                        }
-                lseek(__fd, cur_offs, SEEK_SET);
-                }
-        }
-#endif
 
 fstMunmap(xc->curval_mem, xc->maxvalpos);
 xc->curval_mem = NULL;

--- a/gtkwave4/src/helpers/fst/fstapi.c
+++ b/gtkwave4/src/helpers/fst/fstapi.c
@@ -58,6 +58,7 @@
 #endif
 
 #ifdef __MINGW32__
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 
@@ -334,26 +335,22 @@ return(NULL);
 /*
  * mmap compatibility
  */
-#if defined __CYGWIN__ || defined __MINGW32__
+#if defined __MINGW32__
 #include <limits.h>
 #define fstMmap(__addr,__len,__prot,__flags,__fd,__off) fstMmap2((__len), (__fd), (__off))
-#define fstMunmap(__addr,__len)                         free(__addr)
+#define fstMunmap(__addr,__len)                         UnmapViewOfFile((LPCVOID)__addr)
 
 static void *fstMmap2(size_t __len, int __fd, fst_off_t __off)
 {
-(void)__off;
+HANDLE handle = CreateFileMapping((HANDLE)_get_osfhandle(__fd), NULL,
+				  PAGE_READWRITE, (DWORD)(__len >> 32),
+				  (DWORD)__len, NULL);
+if (!handle) { return NULL; }
 
-unsigned char *pnt = (unsigned char *)malloc(__len);
-fst_off_t cur_offs = lseek(__fd, 0, SEEK_CUR);
-size_t i;
-
-lseek(__fd, 0, SEEK_SET);
-for(i=0;i<__len;i+=SSIZE_MAX)
-        {
-        read(__fd, pnt + i, ((__len - i) >= SSIZE_MAX) ? SSIZE_MAX : (__len - i));
-        }
-lseek(__fd, cur_offs, SEEK_SET);
-return(pnt);
+void *ptr = MapViewOfFileEx(handle, FILE_MAP_READ | FILE_MAP_WRITE,
+			    0, (DWORD)__off, (SIZE_T)__len, (LPVOID)NULL);
+CloseHandle(handle);
+return ptr;
 }
 #else
 #include <sys/mman.h>
@@ -984,14 +981,26 @@ fflush(xc->handle);
  */
 static void fstWriterMmapSanity(void *pnt, const char *file, int line, const char *usage)
 {
-#if !defined(__CYGWIN__) && !defined(__MINGW32__)
-if(pnt == MAP_FAILED)
+if(pnt == NULL
+#ifdef MAP_FAILED
+   || pnt == MAP_FAILED
+#endif
+  )
 	{
 	fprintf(stderr, "fstMmap() assigned to %s failed: errno: %d, file %s, line %d.\n", usage, errno, file, line);
+#if !defined(__MINGW32__)
 	perror("Why");
+#else
+	LPSTR mbuf = NULL;
+	FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM
+		      | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, GetLastError(),
+		      MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+		      (LPSTR)&mbuf, 0, NULL);
+	fprintf(stderr, "%s", mbuf);
+	LocalFree(mbuf);
+#endif
 	pnt = NULL;
 	}
-#endif
 }
 
 
@@ -1037,33 +1046,10 @@ if(!xc->curval_mem)
 
 static void fstDestroyMmaps(struct fstWriterContext *xc, int is_closing)
 {
-#if !defined __CYGWIN__ && !defined __MINGW32__
 (void)is_closing;
-#endif
 
 fstMunmap(xc->valpos_mem, xc->maxhandle * 4 * sizeof(uint32_t));
 xc->valpos_mem = NULL;
-
-#if defined __CYGWIN__ || defined __MINGW32__
-if(xc->curval_mem)
-        {
-        if(!is_closing) /* need to flush out for next emulated mmap() read */
-                {
-                unsigned char *pnt = xc->curval_mem;
-                int __fd = fileno(xc->curval_handle);
-                fst_off_t cur_offs = lseek(__fd, 0, SEEK_CUR);
-                size_t i;
-                size_t __len = xc->maxvalpos;
-
-                lseek(__fd, 0, SEEK_SET);
-                for(i=0;i<__len;i+=SSIZE_MAX)
-                        {
-                        write(__fd, pnt + i, ((__len - i) >= SSIZE_MAX) ? SSIZE_MAX : (__len - i));
-                        }
-                lseek(__fd, cur_offs, SEEK_SET);
-                }
-        }
-#endif
 
 fstMunmap(xc->curval_mem, xc->maxvalpos);
 xc->curval_mem = NULL;


### PR DESCRIPTION
This was reported by a user in nickg/nvc#596.  The FST writer emulates mmap on Windows by copying from the file to a temporary buffer and then flushing that buffer to disk in fstDestroyMmaps.  The problem here is that while `xc->curval_mem` is flushed, `xc->valpos_mem` is not.  One fix would be to duplicate the flushing logic for valpos_mem but it seems better to just use the native Windows MapViewOfFileEx API.  Cygwin has its own mmap emulation layer so the existing POSIX code should work fine there.

I've been using this patch for a while with no reported issues, and I did a full build of GtkWave on MSYS2 and checked it could load FST files created with it.