### PR TITLE
Use PKG_PROG_PKG_CONFIG instead of AC_PATH_CONFIG

### DIFF
--- a/gtkwave3-gtk3/configure.ac
+++ b/gtkwave3-gtk3/configure.ac
@@ -606,7 +606,7 @@ AC_SUBST(LIBJUDY_CFLAGS)
 # ------------- GTK -------------------
 if test "X$GTK3" = "Xyes" ; then
 
-	AC_PATH_PROG(PKG_CONFIG, [pkg-config], [notfound])
+	PKG_PROG_PKG_CONFIG()
         PKG_CHECK_MODULES(GTK, gtk+-3.0 >= 3.0.0)
         GTK_VER=`$PKG_CONFIG gtk+-3.0 --modversion`
 
@@ -646,7 +646,7 @@ if test "X$GTK3" = "Xyes" ; then
 
 else
 
-	AC_PATH_PROG(PKG_CONFIG, [pkg-config], [notfound])
+	PKG_PROG_PKG_CONFIG()
 	PKG_CHECK_MODULES(GTK, gtk+-2.0 >= 2.24.9)
 	GTK_VER=`$PKG_CONFIG gtk+-2.0 --modversion`
 


### PR DESCRIPTION
The AC_PATH_PROG macro fails to select the correct version to support cross-compilation.

A better way would be to use the PKG_PROG_PKG_CONFIG macro from pkg.m4 and then using the $PKG_CONFIG shell variable.

Refer to https://bugs.debian.org/884798 for details.