### PR TITLE
Space as separator for large time values

### DIFF
--- a/gtkwave3-gtk3/src/currenttime.c
+++ b/gtkwave3-gtk3/src/currenttime.c
@@ -326,7 +326,7 @@ while( aux[s] )
 	buf[d++]=aux[s++];
 	if(--c==0 && aux[s] )
 		{
-		buf[d++]=',';
+		buf[d++]=' ';
 		c=3;
 		}
 	}

--- a/gtkwave3-gtk3/src/currenttime.c
+++ b/gtkwave3-gtk3/src/currenttime.c
@@ -21,7 +21,6 @@ static char *marker_label_text ="Marker Time";
 static char *maxtime_label_text_hpos="Max";
 static char *marker_label_text_hpos ="Marker";
 
-
 #ifdef WAVE_ALLOW_GTK3_HEADER_BAR
 static void update_labels_to_header_bar(void)
 {
@@ -29,7 +28,7 @@ if(GLOBALS->header_bar)
 	{
 	char buf[1024];
 
-	sprintf(buf, "%s" ": " "%s" "  |  " "%s" ": " "%s",     
+	sprintf(buf, "%s" ": " "%s" "  |  " "%s" ": " "%s",
 	        gtk_label_get_text(GTK_LABEL(GLOBALS->max_or_marker_label_currenttime_c_1)),
 	        gtk_label_get_text(GTK_LABEL(GLOBALS->maxtimewid_currenttime_c_1)),
 	        gtk_label_get_text(GTK_LABEL(GLOBALS->base_or_curtime_label_currenttime_c_1)),
@@ -315,6 +314,25 @@ if(i)
 	}
 }
 
+void thousands_sep( char *buf, TimeType v )
+{
+char aux[64];
+int s=0,d=0,c;
+sprintf(aux,TTFormat,v);
+c=strlen(aux)%3;
+if( c==0 ) c=3;
+while( aux[s] )
+	{
+	buf[d++]=aux[s++];
+	if(--c==0 && aux[s] )
+		{
+		buf[d++]=',';
+		c=3;
+		}
+	}
+buf[d]=0;
+}
+
 void reformat_time(char *buf, TimeType val, char dim)
 {
 char *pnt;
@@ -372,7 +390,6 @@ if(GLOBALS->scale_to_time_dimension)
 				}
 
 			gval *= mypow;
-
 			if(GLOBALS->scale_to_time_dimension == 's')
 				{
 				sprintf(buf, "%.9g sec", gval);
@@ -386,14 +403,16 @@ if(GLOBALS->scale_to_time_dimension)
 			}
 		}
 	}
+char separated[128];
+thousands_sep( separated, val );
 
 if((i)&&(time_prefix)) /* scan-build on time_prefix, should not be necessary however */
 	{
-	sprintf(buf, TTFormat" %cs", val, time_prefix[i]);
+	sprintf(buf, "%s %cs", separated, time_prefix[i]);
 	}
 	else
 	{
-	sprintf(buf, TTFormat" sec", val);
+	sprintf(buf, "%s sec", separated);
 	}
 }
 

--- a/gtkwave3-gtk3/src/currenttime.c
+++ b/gtkwave3-gtk3/src/currenttime.c
@@ -326,7 +326,9 @@ while( aux[s] )
 	buf[d++]=aux[s++];
 	if(--c==0 && aux[s] )
 		{
-		buf[d++]=' ';
+		buf[d++] = '\xE2'; // UTF-8 for thin space
+		buf[d++] = '\x80';
+		buf[d++] = '\x89';
 		c=3;
 		}
 	}


### PR DESCRIPTION
I'm dealing with a file that contains several seconds of simulation at a MHz clock and reading the time values in GTKWave goes beyond my mental abilities. 

I have modified the `reformat_time` to separete by thousands when there is no `scale_to_time_dimension` set. It looks like this:

![image](https://github.com/gtkwave/gtkwave/assets/1863036/fba94503-21c8-4eb0-a8ce-e8cb539e6f7c)

when you zoom in:

![image](https://github.com/gtkwave/gtkwave/assets/1863036/471168e5-8625-41dd-9506-7979f484fe9a)

I think this probably needs some other changes in the code (maybe in the from/to buttons). If you give me some orientation about what else needs to be done to get this PR accepted, I'll do it. Please bear in mind that I know C but I do not know GTK.
