### PR TITLE
Change project license in appdata

### DIFF
--- a/share/appdata/gtkwave.appdata.xml
+++ b/share/appdata/gtkwave.appdata.xml
@@ -3,7 +3,7 @@
 <component type="desktop">
   <id>io.github.gtkwave.GTKWave</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-2.0-only</project_license>
+  <project_license>GPL-2.0-or-later</project_license>
   <name>GTKWave</name>
   <developer_name>Tony Bybell</developer_name>
   <update_contact>bybell@rocketmail.com</update_contact>


### PR DESCRIPTION
According to `LICENSE.TXT` and the individual file headers the license is "... either version 2 of the License, or (at your option)
any later version." I think that means that the SPDX identifier in the appdata is incorrect, but I'm not very familiar with the intricacies of open source licensing.