### PR TITLE
Fix build in Ubuntu 20.04

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,7 @@ datadir_gtkwave = get_option('datadir') / 'gtkwave3'
 # Required dependency versions
 
 glib_req = '>=2.64.0'
+glib_req_macro = 'GLIB_VERSION_2_64'
 gtk_req = '>=3.24.0'
 zlib_req = '>=1.2.0'
 bzip2_req = '>=1.0.0'
@@ -40,7 +41,6 @@ gtk_unix_print_dep = dependency(
     required: false,
 )
 zlib_dep = dependency('zlib', version: zlib_req)
-bzip2_dep = dependency('bzip2', version: bzip2_req)
 tcl_dep = dependency('tcl', version: tcl_req, required: get_option('tcl'))
 tk_dep = dependency('tk', version: tk_req, required: get_option('tcl'))
 m_dep = cc.find_library('m', required: false)
@@ -55,6 +55,21 @@ gnu_regex_dep = cc.find_library(
     required: host_machine.system() == 'windows',
 )
 thread_dep = dependency('threads', required: false)
+
+bzip2_dep = dependency('bzip2', version: bzip2_req, required: false)
+if not bzip2_dep.found()
+    # pkg-config files for bzip2 aren't always installed,
+    # try to manually find the library as a fallback
+    bzip2_dep = cc.find_library('bz2', has_headers: 'bzlib.h')
+endif
+
+# Limit used glib functions to minimum required version
+
+add_project_arguments(
+    '-DGLIB_VERSION_MIN_REQUIRED=' + glib_req_macro,
+    '-DGLIB_VERSION_MAX_ALLOWED=' + glib_req_macro,
+    language: 'c',
+)
 
 # External programs
 

--- a/src/gw-time-display.c
+++ b/src/gw-time-display.c
@@ -134,7 +134,7 @@ struct _GwTimeDisplay
     GtkWidget *cursor_value;
 };
 
-G_DEFINE_FINAL_TYPE(GwTimeDisplay, gw_time_display, GTK_TYPE_BOX)
+G_DEFINE_TYPE(GwTimeDisplay, gw_time_display, GTK_TYPE_BOX)
 
 static void gw_time_display_class_init(GwTimeDisplayClass *klass)
 {

--- a/src/wave_view.c
+++ b/src/wave_view.c
@@ -14,7 +14,7 @@ struct _GwWaveView
     gboolean dirty;
 };
 
-G_DEFINE_FINAL_TYPE(GwWaveView, gw_wave_view, GTK_TYPE_DRAWING_AREA)
+G_DEFINE_TYPE(GwWaveView, gw_wave_view, GTK_TYPE_DRAWING_AREA)
 
 static const int wave_rgb_rainbow[WAVE_NUM_RAINBOW] = WAVE_RAINBOW_RGB;
 


### PR DESCRIPTION
This PR fixes an issue on some distributions, where `bzip2` couldn't be located by meson. It also enables some GLib macros to ensure that the code keeps compatible with our minimum required GLib version.

I did choose Ubuntu 20.04 LTS as the oldest version that should be supported by GTKWave 3.4. In my opinion a 3.5 year old target is a good compromise between supporting older distros and not being limited by having to support older library versions. Users on even older versions can still use GTKWave 3.3 (LTS) or the Flatpak version.