### PR TITLE
Remove dependency on gedit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Replaced hamburger menu with traditional menubar.
 - Improved the readability of the cursor and marker time display.
 - Migrated from autotools to meson.
+- Changed the fallback text editor from gedit to the default editor that is associated with the source filetype.
 
 ### Added
 
@@ -21,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added OpenBSD and FreeBSD OS support for unbuffered FST I/O.
 - Added `dbl_mant_dig_overrides` rc environment variable.
 - Added `disable_antialiasing` rc variable.
+- Added `editor_run_in_terminal` rc variable.
 
 ### Removed
 

--- a/man/gtkwaverc.5
+++ b/man/gtkwaverc.5
@@ -202,6 +202,9 @@ A nonzero value indicates that dynamic resizing should be initially enabled (def
 This is used to specify a string (quotes mandatory) for when gtkwave invokes a text editor (e.g., Open Source Definition).  Examples are:
 editor "vimx -g +%d %s", editor "gedit +%d %s", editor "emacs +%d %s", and for OSX, editor "mate -l %d %s".  The %d may be combined with other characters in a string such as +, etc.  The %s argument must stand by itself.  Note that if this rc variable is not set, 
 then the environment variable GTKWAVE_EDITOR will be consulted next, then finally gedit will be used (if found).
+.TP
+\fBeditor_run_in_terminal\fR <\fIvalue\fP>
+A nonzero value indicates that the editor is run in a terminal window. Default is disabled.
 .TP 
 \fBenable_fast_exit\fR <\fIvalue\fP>
 Allows exit without bringing up a confirmation requester. The default is nonzero/yes.

--- a/src/globals.c
+++ b/src/globals.c
@@ -622,6 +622,7 @@ static const struct Global globals_base_values = {
     0, /* rc_line_no 318 */
     1, /* possibly_use_rc_defaults 319 */
     NULL, /* editor_string */
+    FALSE, /* editor_run_in_terminal */
 
     /*
      * regex.c

--- a/src/globals.h
+++ b/src/globals.h
@@ -644,6 +644,7 @@ struct Global
     int rc_line_no; /* from rc.c 336 */
     int possibly_use_rc_defaults; /* from rc.c 337 */
     char *editor_name; /* from rc.c */
+    gboolean editor_run_in_terminal; /* from rc.c */
 
     /*
      * regex.c

--- a/src/rc.c
+++ b/src/rc.c
@@ -245,6 +245,13 @@ int f_editor(const char *str)
     return (0);
 }
 
+int f_editor_run_in_terminal(const char *str)
+{
+    DEBUG(printf("f_editor_run_in_terminal(\"%s\")\n", str));
+    GLOBALS->editor_run_in_terminal = atoi_64(str) ? 1 : 0;
+    return (0);
+}
+
 int f_enable_fast_exit(const char *str)
 {
     DEBUG(printf("f_enable_fast_exit(\"%s\")\n", str));
@@ -885,6 +892,7 @@ static struct rc_entry rcitems[] = {
     {"dragzoom_threshold", f_dragzoom_threshold},
     {"dynamic_resizing", f_dynamic_resizing},
     {"editor", f_editor},
+    {"editor_run_in_terminal", f_editor_run_in_terminal},
     {"enable_fast_exit", f_enable_fast_exit},
     {"enable_ghost_marker", f_enable_ghost_marker},
     {"enable_horiz_grid", f_enable_horiz_grid},


### PR DESCRIPTION
This PR removes the hard coded support for gedit. Instead GTKWave will fall back to use the default editor that is associated with the source file type. This isn't as good as the hard coded gedit support, because there is no generic way of opening a text file at a specific line, but at least the right source file will be opened.

A new rc variable can now be used to run editors in a separate terminal, which makes it possible to use text mode editors even if GTKWave itself wasn't run from a terminal.

The new code should now also work on Windows, but I haven't tested that yet.