### PR TITLE
Remove old ifdefs and rcvars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Removed setting to disable the "Alternate Wheel Mode".
 - Removed rc variables:
     - `alt_wheel_mode`
+    - `atomic_vectors`
     - `force_toolbars`
     - `hide_sst`
     - `hier_grouping`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - `use_standard_clicking`
     - `use_standard_trace_select`
     - `use_toolbutton_interface`
+    - `vcd_explicit_zero_subscripts`
 
 ### Fixed
 

--- a/examples/gtkwaverc
+++ b/examples/gtkwaverc
@@ -71,8 +71,6 @@ constant_marker_update yes
 show_grid yes
 show_base_symbols no
 
-vcd_explicit_zero_subscripts no
-
 disable_mouseover no
 clipboard_mouseover yes
 

--- a/examples/gtkwaverc
+++ b/examples/gtkwaverc
@@ -71,7 +71,6 @@ constant_marker_update yes
 show_grid yes
 show_base_symbols no
 
-atomic_vectors yes
 vcd_explicit_zero_subscripts no
 
 disable_mouseover no

--- a/man/gtkwaverc.5
+++ b/man/gtkwaverc.5
@@ -344,9 +344,6 @@ Uses anti-aliased pango fonts (GTK2) rather than bitmapped X11 ones. Default is 
 \fBuse_roundcaps\fR <\fIvalue\fP>
 A nonzero value indicates that vector traces should be drawn with rounded caps rather than perpendicular ones. The default for this is zero.
 .TP 
-\fBvcd_explicit_zero_subscripts\fR <\fIvalue\fP>
-indicates that signal names should be stored internally as name.bitnumber when enabled. When disabled, a more "normal" ordering of name[bitnumber] is used. Note that when disabled, the Bundle Up and Bundle Down options are disabled in the Signal Search Regexp,  Signal Search Hierarchy, and Signal Search Tree options. This is necessary as the internal data structures for signals are represented with one "less" level of hierarchy than when enabled and those functions would not work properly. This should not be an issue if atomic_vectors are enabled. Default for vcd_explicit_zero_subscripts is disabled.
-.TP 
 \fBvcd_preserve_glitches\fR <\fIvalue\fP>
 indicates that any repeat equal values for a net spanning different time values in the VCD/FST file are not to be compressed into a single value change but should remain in order to allow glitches to be present for this case. Default for vcd_preserve_glitches is disabled.
 .TP 

--- a/man/gtkwaverc.5
+++ b/man/gtkwaverc.5
@@ -28,9 +28,6 @@ gaps in analog traces, this value is too low.
 \fBappend_vcd_hier\fR <\fIvalue\fP>
 Allows the specification of a prefix hierarchy for VCD files. This can be done in "pieces," so that multiple layers of hierarchy are prepended to symbol names with the most significant addition occurring first (see .gtkwaverc in the  examples/vcd directory). The intended use of this is to have the ability to add "project" prefixes which allow easier selection of everything from the tree hierarchy.
 .TP 
-\fBatomic_vectors\fR <\fIvalue\fP>
-Speeds up vcd loading and takes up less memory. This option is deprecated; it is currently the default.
-.TP 
 \fBautocoalesce\fR <\fIvalue\fP>
 A nonzero value enables autocoalescing of VCD vectors when applicable. This may be toggled dynamically during wave viewer usage.
 .TP 

--- a/src/ae2.c
+++ b/src/ae2.c
@@ -821,37 +821,12 @@ if(GLOBALS->fast_tree_sort)
 	{
 	for(i=0;i<(unsigned int)GLOBALS->numfacs;i++)
 		{
-#ifdef WAVE_HIERFIX
-		char *subst;
-		char ch;
-#endif
 		GLOBALS->facs[i]=&monolithic_sym[i];
-#ifdef WAVE_HIERFIX
-		while((ch=(*subst)))
-			{
-			if(ch==GLOBALS->hier_delimeter) { *subst=VCDNAM_HIERSORT; }	/* forces sort at hier boundaries */
-			subst++;
-			}
-#endif
 		}
 
 /* SPLASH */                            splash_sync(3, 5);
 	fprintf(stderr, AET2_RDLOAD"Sorting facilities at hierarchy boundaries.\n");
 	wave_heapsort(GLOBALS->facs,GLOBALS->numfacs);
-
-#ifdef WAVE_HIERFIX
-	for(i=0;i<GLOBALS->numfacs;i++)
-		{
-		char *subst, ch;
-
-		subst=GLOBALS->facs[i]->name;
-		while((ch=(*subst)))
-			{
-			if(ch==VCDNAM_HIERSORT) { *subst=GLOBALS->hier_delimeter; }	/* restore back to normal */
-			subst++;
-			}
-		}
-#endif
 
 	GLOBALS->facs_are_sorted=1;
 

--- a/src/ae2.c
+++ b/src/ae2.c
@@ -499,14 +499,7 @@ GLOBALS->ae2_process_mask = calloc_2(1, GLOBALS->numfacs/8+1);
 GLOBALS->ae2_fr=calloc_2(GLOBALS->numfacs, sizeof(AE2_FACREF));
 GLOBALS->ae2_lx2_table=(struct lx2_entry **)calloc_2(GLOBALS->numfacs, sizeof(struct lx2_entry *));
 
-if(!GLOBALS->fast_tree_sort)
-        {
-        GLOBALS->do_hier_compress = 0;
-        }
-        else
-	{
         hier_auto_enable(); /* enable if greater than threshold */
-        }
 
 init_facility_pack();
 
@@ -788,7 +781,7 @@ freeze_facility_pack();
 /* SPLASH */                            splash_sync(2, 5);
 GLOBALS->facs=(struct symbol **)malloc_2(GLOBALS->numfacs*sizeof(struct symbol *));
 
-if(GLOBALS->fast_tree_sort)
+if(1 /* GLOBALS->fast_tree_sort */)
 	{
 	for(i=0;i<(unsigned int)GLOBALS->numfacs;i++)
 		{

--- a/src/analyzer.c
+++ b/src/analyzer.c
@@ -1143,9 +1143,6 @@ int TracesReorder(int mode)
 {
     Trptr t, prev = NULL;
     Trptr *tsort, *tsort_pnt;
-#ifdef WAVE_HIERFIX
-    char *subst, ch;
-#endif
     int i;
     int (*cptr)(const void *, const void *);
 
@@ -1163,16 +1160,6 @@ int TracesReorder(int mode)
             exit(255);
         }
         *(tsort_pnt++) = t;
-
-#ifdef WAVE_HIERFIX
-        if ((subst = t->name))
-            while ((ch = (*subst))) {
-                if (ch == GLOBALS->hier_delimeter) {
-                    *subst = VCDNAM_HIERSORT;
-                } /* forces sort at hier boundaries */
-                subst++;
-            }
-#endif
 
         t = t->t_next;
     }
@@ -1277,16 +1264,6 @@ int TracesReorder(int mode)
         }
 
         prev = t;
-
-#ifdef WAVE_HIERFIX
-        if ((subst = t->name))
-            while ((ch = (*subst))) {
-                if (ch == VCDNAM_HIERSORT) {
-                    *subst = GLOBALS->hier_delimeter;
-                } /* restore hier */
-                subst++;
-            }
-#endif
     }
 
     GLOBALS->traces.last = prev;

--- a/src/extload.c
+++ b/src/extload.c
@@ -1975,40 +1975,16 @@ if(GLOBALS->fast_tree_sort)
 	for(i=0;i<GLOBALS->numfacs;i++)
 		{
 		char *subst;
-#ifdef WAVE_HIERFIX
-		char ch;
-#endif
 		int len;
 
 		GLOBALS->facs[i]=&GLOBALS->extload_sym_block[i];
 		subst=GLOBALS->facs[i]->name;
 	        if((len=strlen(subst))>GLOBALS->longestname) GLOBALS->longestname=len;
-#ifdef WAVE_HIERFIX
-		while((ch=(*subst)))
-			{
-			if(ch==GLOBALS->hier_delimeter) { *subst=VCDNAM_HIERSORT; }	/* forces sort at hier boundaries */
-			subst++;
-			}
-#endif
 		}
 
 /* SPLASH */                            splash_sync(3, 5);
 	fprintf(stderr, EXTLOAD"Sorting facilities at hierarchy boundaries.\n");
 	wave_heapsort(GLOBALS->facs,GLOBALS->numfacs);
-
-#ifdef WAVE_HIERFIX
-	for(i=0;i<GLOBALS->numfacs;i++)
-		{
-		char *subst, ch;
-
-		subst=GLOBALS->facs[i]->name;
-		while((ch=(*subst)))
-			{
-			if(ch==VCDNAM_HIERSORT) { *subst=GLOBALS->hier_delimeter; }	/* restore back to normal */
-			subst++;
-			}
-		}
-#endif
 
 	GLOBALS->facs_are_sorted=1;
 

--- a/src/extload.c
+++ b/src/extload.c
@@ -1375,12 +1375,9 @@ else
 	        symadd_name_exists_sym_exists(s,str,0);
 		GLOBALS->extload_prevsymroot = GLOBALS->extload_prevsym = NULL;
 
-                if(GLOBALS->fast_tree_sort)
-                       	{
                         len = sprintf_2_sdd(buf, fnam_prev,GLOBALS->extload_node_block[i].msi, GLOBALS->extload_node_block[i].lsi);
                         fsdb_append_graft_chain(len, buf, i, GLOBALS->extload_npar[i & F_NAME_MODULUS]);
 			if(fnam) strcpy(fnam_prev, fnam);
-                        }
 		}
 	else if (
 			((f->len==1)&&(!(f->flags&(VZT_RD_SYM_F_INTEGER|VZT_RD_SYM_F_DOUBLE|VZT_RD_SYM_F_STRING)))&&
@@ -1428,12 +1425,9 @@ else
 			GLOBALS->extload_prevsymroot = GLOBALS->extload_prevsym = s;
 			}
 
-                if(GLOBALS->fast_tree_sort)
-                       	{
                         len = sprintf_2_sd(buf, fnam_prev, GLOBALS->extload_node_block[i].msi);
                         fsdb_append_graft_chain(len, buf, i, GLOBALS->extload_npar[i & F_NAME_MODULUS]);
 			if(fnam) strcpy(fnam_prev, fnam);
-                       	}
 
 		}
 		else
@@ -1473,8 +1467,6 @@ else
 			GLOBALS->mvlfacs_vzt_c_3[i].len=32;
 			}
 
-                if(GLOBALS->fast_tree_sort)
-                       	{
                         fsdb_append_graft_chain(strlen(fnam_prev), fnam_prev, i, GLOBALS->extload_npar[i & F_NAME_MODULUS]);
 			if(fnam) strcpy(fnam_prev, fnam);
                        	}
@@ -1838,14 +1830,7 @@ GLOBALS->extload_inv_idcodes=(int *)calloc_2(max_idcode+1, sizeof(int));
 GLOBALS->extload_npar=(struct tree **)calloc_2(F_NAME_MODULUS+1, sizeof(struct tree *));
 #endif
 
-if(!GLOBALS->fast_tree_sort)
-        {
-        GLOBALS->do_hier_compress = 0;
-        }
-	else
-	{
-	hier_auto_enable(); /* enable if greater than threshold */
-	}
+hier_auto_enable(); /* enable if greater than threshold */
 
 GLOBALS->f_name_build_buf_len = 128;
 GLOBALS->f_name_build_buf = malloc_2(GLOBALS->f_name_build_buf_len + 1);
@@ -1941,7 +1926,7 @@ freeze_facility_pack();
 
 GLOBALS->facs=(struct symbol **)malloc_2(GLOBALS->numfacs*sizeof(struct symbol *));
 
-if(GLOBALS->fast_tree_sort)
+if(1 /* GLOBALS->fast_tree_sort */)
         {
         for(i=0;i<GLOBALS->numfacs;i++)
                 {

--- a/src/fst.c
+++ b/src/fst.c
@@ -653,11 +653,7 @@ TimeType fst_main(char *fname, char *skip_start, char *skip_end)
     GLOBALS->mvlfacs_fst_alias = calloc_2(GLOBALS->numfacs, sizeof(fstHandle));
     GLOBALS->mvlfacs_fst_rvs_alias = calloc_2(GLOBALS->numfacs, sizeof(fstHandle));
 
-    if (!GLOBALS->fast_tree_sort) {
-        GLOBALS->do_hier_compress = 0;
-    } else {
-        hier_auto_enable(); /* enable if greater than threshold */
-    }
+    hier_auto_enable(); /* enable if greater than threshold */
 
     init_facility_pack();
 
@@ -1020,10 +1016,8 @@ TimeType fst_main(char *fname, char *skip_start, char *skip_end)
             symadd_name_exists_sym_exists(s, str, 0);
             prevsymroot = prevsym = NULL;
 
-            if (GLOBALS->fast_tree_sort) {
-                len = sprintf_2_sdd(buf, nnam, node_block[i].msi, node_block[i].lsi);
-                fst_append_graft_chain(len, buf, i, npar);
-            }
+            len = sprintf_2_sdd(buf, nnam, node_block[i].msi, node_block[i].lsi);
+            fst_append_graft_chain(len, buf, i, npar);
         } else {
             int gatecmp = (f->len == 1) &&
                           (!(f->flags &
@@ -1068,10 +1062,8 @@ TimeType fst_main(char *fname, char *skip_start, char *skip_end)
                     prevsymroot = prevsym = s;
                 }
 
-                if (GLOBALS->fast_tree_sort) {
-                    len = sprintf_2_sd(buf, nnam, node_block[i].msi);
-                    fst_append_graft_chain(len, buf, i, npar);
-                }
+                len = sprintf_2_sd(buf, nnam, node_block[i].msi);
+                fst_append_graft_chain(len, buf, i, npar);
             } else {
                 int len = f_name_len[(i)&F_NAME_MODULUS];
 
@@ -1107,9 +1099,7 @@ TimeType fst_main(char *fname, char *skip_start, char *skip_end)
                     }
                 }
 
-                if (GLOBALS->fast_tree_sort) {
-                    fst_append_graft_chain(strlen(nnam), nnam, i, npar);
-                }
+                fst_append_graft_chain(strlen(nnam), nnam, i, npar);
             }
         }
 
@@ -1312,74 +1302,21 @@ TimeType fst_main(char *fname, char *skip_start, char *skip_end)
 
     GLOBALS->fst_maxhandle = numvars;
 
-    if (GLOBALS->fast_tree_sort) {
-        /* SPLASH */ splash_sync(2, 5);
-        fprintf(stderr, FST_RDLOAD "Building facility hierarchy tree.\n");
+    /* SPLASH */ splash_sync(2, 5);
+    fprintf(stderr, FST_RDLOAD "Building facility hierarchy tree.\n");
 
-        init_tree();
-        treegraft(&GLOBALS->treeroot);
+    init_tree();
+    treegraft(&GLOBALS->treeroot);
 
-        /* SPLASH */ splash_sync(3, 5);
+    /* SPLASH */ splash_sync(3, 5);
 
-        fprintf(stderr, FST_RDLOAD "Sorting facility hierarchy tree.\n");
-        treesort(GLOBALS->treeroot, NULL);
-        /* SPLASH */ splash_sync(4, 5);
-        order_facs_from_treesort(GLOBALS->treeroot, &GLOBALS->facs);
+    fprintf(stderr, FST_RDLOAD "Sorting facility hierarchy tree.\n");
+    treesort(GLOBALS->treeroot, NULL);
+    /* SPLASH */ splash_sync(4, 5);
+    order_facs_from_treesort(GLOBALS->treeroot, &GLOBALS->facs);
 
-        /* SPLASH */ splash_sync(5, 5);
-        GLOBALS->facs_are_sorted = 1;
-    } else {
-        /* SPLASH */ splash_sync(2, 5);
-        for (i = 0; i < GLOBALS->numfacs; i++) {
-            char *subst, ch;
-            int esc = 0;
-
-            subst = GLOBALS->facs[i]->name;
-            while ((ch = (*subst))) {
-                if ((ch == GLOBALS->hier_delimeter) && (esc)) {
-                    *subst = VCDNAM_ESCAPE;
-                } /* forces sort at hier boundaries */
-                else if (ch == '\\') {
-                    esc = 1;
-                    GLOBALS->escaped_names_found_vcd_c_1 = 1;
-                }
-                subst++;
-            }
-        }
-
-        /* SPLASH */ splash_sync(3, 5);
-        fprintf(stderr, FST_RDLOAD "Sorting facilities at hierarchy boundaries.\n");
-        wave_heapsort(GLOBALS->facs, GLOBALS->numfacs);
-
-        GLOBALS->facs_are_sorted = 1;
-
-        /* SPLASH */ splash_sync(4, 5);
-        fprintf(stderr, FST_RDLOAD "Building facility hierarchy tree.\n");
-
-        init_tree();
-        for (i = 0; i < GLOBALS->numfacs; i++) {
-            char *nf = GLOBALS->facs[i]->name;
-            build_tree_from_name(nf, i);
-        }
-        /* SPLASH */ splash_sync(5, 5);
-        if (GLOBALS->escaped_names_found_vcd_c_1) {
-            for (i = 0; i < GLOBALS->numfacs; i++) {
-                char *subst, ch;
-                subst = GLOBALS->facs[i]->name;
-                while ((ch = (*subst))) {
-                    if (ch == VCDNAM_ESCAPE) {
-                        *subst = GLOBALS->hier_delimeter;
-                    } /* restore back to normal */
-                    subst++;
-                }
-            }
-        }
-        treegraft(&GLOBALS->treeroot);
-        treesort(GLOBALS->treeroot, NULL);
-        if (GLOBALS->escaped_names_found_vcd_c_1) {
-            treenamefix(GLOBALS->treeroot);
-        }
-    }
+    /* SPLASH */ splash_sync(5, 5);
+    GLOBALS->facs_are_sorted = 1;
 
 #if 0
 {

--- a/src/fst.c
+++ b/src/fst.c
@@ -1336,15 +1336,9 @@ TimeType fst_main(char *fname, char *skip_start, char *skip_end)
 
             subst = GLOBALS->facs[i]->name;
             while ((ch = (*subst))) {
-#ifdef WAVE_HIERFIX
-                if (ch == GLOBALS->hier_delimeter) {
-                    *subst = (!esc) ? VCDNAM_HIERSORT : VCDNAM_ESCAPE;
-                } /* forces sort at hier boundaries */
-#else
                 if ((ch == GLOBALS->hier_delimeter) && (esc)) {
                     *subst = VCDNAM_ESCAPE;
                 } /* forces sort at hier boundaries */
-#endif
                 else if (ch == '\\') {
                     esc = 1;
                     GLOBALS->escaped_names_found_vcd_c_1 = 1;
@@ -1356,20 +1350,6 @@ TimeType fst_main(char *fname, char *skip_start, char *skip_end)
         /* SPLASH */ splash_sync(3, 5);
         fprintf(stderr, FST_RDLOAD "Sorting facilities at hierarchy boundaries.\n");
         wave_heapsort(GLOBALS->facs, GLOBALS->numfacs);
-
-#ifdef WAVE_HIERFIX
-        for (i = 0; i < GLOBALS->numfacs; i++) {
-            char *subst, ch;
-
-            subst = GLOBALS->facs[i]->name;
-            while ((ch = (*subst))) {
-                if (ch == VCDNAM_HIERSORT) {
-                    *subst = GLOBALS->hier_delimeter;
-                } /* restore back to normal */
-                subst++;
-            }
-        }
-#endif
 
         GLOBALS->facs_are_sorted = 1;
 

--- a/src/ghw.c
+++ b/src/ghw.c
@@ -359,23 +359,12 @@ static void ghw_sortfacs(void)
 
     for (i = 0; i < GLOBALS->numfacs; i++) {
         char *subst;
-#ifdef WAVE_HIERFIX
-        char ch;
-#endif
         int len;
         struct symbol *curnode = GLOBALS->facs[i];
 
         subst = curnode->name;
         if ((len = strlen(subst)) > GLOBALS->longestname)
             GLOBALS->longestname = len;
-#ifdef WAVE_HIERFIX
-        while ((ch = (*subst))) {
-            if (ch == GLOBALS->hier_delimeter) {
-                *subst = VCDNAM_HIERSORT;
-            } /* forces sort at hier boundaries */
-            subst++;
-        }
-#endif
     }
 
     wave_heapsort(GLOBALS->facs, GLOBALS->numfacs);
@@ -394,20 +383,6 @@ static void ghw_sortfacs(void)
         incinerate_whichcache_tree(GLOBALS->gwt_corr_ghw_c_1);
         GLOBALS->gwt_corr_ghw_c_1 = NULL;
     }
-
-#ifdef WAVE_HIERFIX
-    for (i = 0; i < GLOBALS->numfacs; i++) {
-        char *subst, ch;
-
-        subst = GLOBALS->facs[i]->name;
-        while ((ch = (*subst))) {
-            if (ch == VCDNAM_HIERSORT) {
-                *subst = GLOBALS->hier_delimeter;
-            } /* restore back to normal */
-            subst++;
-        }
-    }
-#endif
 
     GLOBALS->facs_are_sorted = 1;
 }

--- a/src/globals.c
+++ b/src/globals.c
@@ -935,7 +935,6 @@ static const struct Global globals_base_values = {
     -1, /* vcd_warning_filesize 472 */
     1, /* autocoalesce 473 */
     0, /* autocoalesce_reversal */
-    -1, /* vcd_explicit_zero_subscripts 474 */
     0, /* convert_to_reals 475 */
     0, /* make_vcd_save_file 477 */
     0, /* vcd_preserve_glitches 478 */
@@ -1710,7 +1709,6 @@ void reload_into_new_context_2(void)
     new_globals->use_maxtime_display = GLOBALS->use_maxtime_display;
     new_globals->use_nonprop_fonts = GLOBALS->use_nonprop_fonts;
     new_globals->use_roundcaps = GLOBALS->use_roundcaps;
-    new_globals->vcd_explicit_zero_subscripts = GLOBALS->vcd_explicit_zero_subscripts;
     new_globals->vcd_preserve_glitches = GLOBALS->vcd_preserve_glitches;
     new_globals->vcd_preserve_glitches_real = GLOBALS->vcd_preserve_glitches_real;
     new_globals->vcd_warning_filesize = GLOBALS->vcd_warning_filesize;

--- a/src/globals.c
+++ b/src/globals.c
@@ -851,7 +851,6 @@ static const struct Global globals_base_values = {
     '.', /* hier_delimeter 447 */
     0, /* hier_was_explicitly_set 448 */
     0x00, /* alt_hier_delimeter 449 */
-    1, /* fast_tree_sort 450 */
     NULL, /* facs2_tree_c_1 451 */
     0, /* facs2_pos_tree_c_1 452 */
     NULL, /* talloc_pool_base */

--- a/src/globals.c
+++ b/src/globals.c
@@ -937,7 +937,6 @@ static const struct Global globals_base_values = {
     0, /* autocoalesce_reversal */
     -1, /* vcd_explicit_zero_subscripts 474 */
     0, /* convert_to_reals 475 */
-    1, /* atomic_vectors 476 */
     0, /* make_vcd_save_file 477 */
     0, /* vcd_preserve_glitches 478 */
     0, /* vcd_preserve_glitches_real */
@@ -1669,7 +1668,6 @@ void reload_into_new_context_2(void)
     new_globals->color_ltblue = GLOBALS->color_ltblue;
     new_globals->color_gmstrd = GLOBALS->color_gmstrd;
 
-    new_globals->atomic_vectors = GLOBALS->atomic_vectors;
     new_globals->autoname_bundles = GLOBALS->autoname_bundles;
     new_globals->autocoalesce = GLOBALS->autocoalesce;
     new_globals->autocoalesce_reversal = GLOBALS->autocoalesce_reversal;

--- a/src/globals.h
+++ b/src/globals.h
@@ -916,7 +916,6 @@ struct Global
     char autocoalesce_reversal; /* from vcd.c 504 */
     int vcd_explicit_zero_subscripts; /* from vcd.c 505 */
     char convert_to_reals; /* from vcd.c 506 */
-    char atomic_vectors; /* from vcd.c 507 */
     char make_vcd_save_file; /* from vcd.c 508 */
     char vcd_preserve_glitches; /* from vcd.c 509 */
     char vcd_preserve_glitches_real;

--- a/src/globals.h
+++ b/src/globals.h
@@ -830,7 +830,6 @@ struct Global
     char hier_delimeter; /* from tree.c 477 */
     char hier_was_explicitly_set; /* from tree.c 478 */
     char alt_hier_delimeter; /* from tree.c 479 */
-    int fast_tree_sort; /* from tree.c 480 */
     struct symbol **facs2_tree_c_1; /* from tree.c 481 */
     int facs2_pos_tree_c_1; /* from tree.c 482 */
     unsigned char *talloc_pool_base;

--- a/src/globals.h
+++ b/src/globals.h
@@ -914,7 +914,6 @@ struct Global
     int vcd_warning_filesize; /* from vcd.c 502 */
     char autocoalesce; /* from vcd.c 503 */
     char autocoalesce_reversal; /* from vcd.c 504 */
-    int vcd_explicit_zero_subscripts; /* from vcd.c 505 */
     char convert_to_reals; /* from vcd.c 506 */
     char make_vcd_save_file; /* from vcd.c 508 */
     char vcd_preserve_glitches; /* from vcd.c 509 */

--- a/src/lx2.c
+++ b/src/lx2.c
@@ -313,15 +313,9 @@ TimeType lx2_main(char *fname, char *skip_start, char *skip_end)
             if ((len = strlen(subst = GLOBALS->facs[i]->name)) > GLOBALS->longestname)
                 GLOBALS->longestname = len;
             while ((ch = (*subst))) {
-#ifdef WAVE_HIERFIX
-                if (ch == GLOBALS->hier_delimeter) {
-                    *subst = (!esc) ? VCDNAM_HIERSORT : VCDNAM_ESCAPE;
-                } /* forces sort at hier boundaries */
-#else
                 if ((ch == GLOBALS->hier_delimeter) && (esc)) {
                     *subst = VCDNAM_ESCAPE;
                 } /* forces sort at hier boundaries */
-#endif
                 else if (ch == '\\') {
                     esc = 1;
                     GLOBALS->escaped_names_found_vcd_c_1 = 1;
@@ -333,20 +327,6 @@ TimeType lx2_main(char *fname, char *skip_start, char *skip_end)
         /* SPLASH */ splash_sync(3, 5);
         fprintf(stderr, LXT2_RDLOAD "Sorting facilities at hierarchy boundaries.\n");
         wave_heapsort(GLOBALS->facs, GLOBALS->numfacs);
-
-#ifdef WAVE_HIERFIX
-        for (i = 0; i < GLOBALS->numfacs; i++) {
-            char *subst, ch;
-
-            subst = GLOBALS->facs[i]->name;
-            while ((ch = (*subst))) {
-                if (ch == VCDNAM_HIERSORT) {
-                    *subst = GLOBALS->hier_delimeter;
-                } /* restore back to normal */
-                subst++;
-            }
-        }
-#endif
 
         GLOBALS->facs_are_sorted = 1;
 

--- a/src/lxt.c
+++ b/src/lxt.c
@@ -1872,15 +1872,9 @@ TimeType lxt_main(char *fname)
         if ((len = strlen(subst = GLOBALS->facs[i]->name)) > GLOBALS->longestname)
             GLOBALS->longestname = len;
         while ((ch = (*subst))) {
-#ifdef WAVE_HIERFIX
-            if (ch == GLOBALS->hier_delimeter) {
-                *subst = (!esc) ? VCDNAM_HIERSORT : VCDNAM_ESCAPE;
-            } /* forces sort at hier boundaries */
-#else
             if ((ch == GLOBALS->hier_delimeter) && (esc)) {
                 *subst = VCDNAM_ESCAPE;
             } /* forces sort at hier boundaries */
-#endif
             else if (ch == '\\') {
                 esc = 1;
                 GLOBALS->escaped_names_found_vcd_c_1 = 1;
@@ -1892,24 +1886,6 @@ TimeType lxt_main(char *fname)
     fprintf(stderr, LXTHDR "Sorting facilities at hierarchy boundaries...");
     wave_heapsort(GLOBALS->facs, GLOBALS->numfacs);
     fprintf(stderr, "sorted.\n");
-
-#ifdef WAVE_HIERFIX
-    for (i = 0; i < GLOBALS->numfacs; i++) {
-        char *subst, ch;
-
-        subst = GLOBALS->facs[i]->name;
-        while ((ch = (*subst))) {
-            if (ch == VCDNAM_HIERSORT) {
-                *subst = GLOBALS->hier_delimeter;
-            } /* restore back to normal */
-            subst++;
-        }
-
-#ifdef DEBUG_FACILITIES
-        printf("%-4d %s\n", i, facs[i]->name);
-#endif
-    }
-#endif
 
     GLOBALS->facs_are_sorted = 1;
 

--- a/src/main.c
+++ b/src/main.c
@@ -1757,15 +1757,6 @@ loader_check_head:
         }
     }
 
-    if (((GLOBALS->loaded_file_type != FST_FILE) && (GLOBALS->loaded_file_type != AE2_FILE)
-#if defined(EXTLOAD_SUFFIX)
-         && (GLOBALS->loaded_file_type != EXTLOAD_FILE)
-#endif
-             ) ||
-        (!GLOBALS->fast_tree_sort)) {
-        GLOBALS->do_hier_compress = 0; /* for now, add more file formats in the future */
-    }
-
     /* deallocate the symbol hash table */
     sym_hash_destroy(GLOBALS);
 

--- a/src/main.c
+++ b/src/main.c
@@ -841,7 +841,6 @@ int main_2(int opt_vcd, int argc, char *argv[])
         GLOBALS->use_maxtime_display = old_g->use_maxtime_display;
         GLOBALS->use_nonprop_fonts = old_g->use_nonprop_fonts;
         GLOBALS->use_roundcaps = old_g->use_roundcaps;
-        GLOBALS->vcd_explicit_zero_subscripts = old_g->vcd_explicit_zero_subscripts;
         GLOBALS->vcd_preserve_glitches = old_g->vcd_preserve_glitches;
         GLOBALS->vcd_preserve_glitches_real = old_g->vcd_preserve_glitches_real;
         GLOBALS->vcd_warning_filesize = old_g->vcd_warning_filesize;

--- a/src/main.c
+++ b/src/main.c
@@ -802,7 +802,6 @@ int main_2(int opt_vcd, int argc, char *argv[])
         GLOBALS->color_ltblue = old_g->color_ltblue;
         GLOBALS->color_gmstrd = old_g->color_gmstrd;
 
-        GLOBALS->atomic_vectors = old_g->atomic_vectors;
         GLOBALS->autoname_bundles = old_g->autoname_bundles;
         GLOBALS->autocoalesce = old_g->autocoalesce;
         GLOBALS->autocoalesce_reversal = old_g->autocoalesce_reversal;

--- a/src/rc.c
+++ b/src/rc.c
@@ -642,13 +642,6 @@ int f_ruler_step(const char *str)
     return (0);
 }
 
-int f_vcd_explicit_zero_subscripts(const char *str)
-{
-    DEBUG(printf("f_vcd_explicit_zero_subscripts(\"%s\")\n", str));
-    GLOBALS->vcd_explicit_zero_subscripts = atoi_64(str) ? 0 : -1; /* 0==yes, -1==no */
-    return (0);
-}
-
 int f_vcd_preserve_glitches(const char *str)
 {
     DEBUG(printf("f_vcd_preserve_glitches(\"%s\")\n", str));
@@ -924,7 +917,6 @@ static struct rc_entry rcitems[] = {
     {"use_nonprop_fonts", f_use_nonprop_fonts},
     {"use_pango_fonts", f_use_pango_fonts},
     {"use_roundcaps", f_use_roundcaps},
-    {"vcd_explicit_zero_subscripts", f_vcd_explicit_zero_subscripts},
     {"vcd_preserve_glitches", f_vcd_preserve_glitches},
     {"vcd_preserve_glitches_real", f_vcd_preserve_glitches_real},
     {"vcd_warning_filesize", f_vcd_warning_filesize},

--- a/src/rc.c
+++ b/src/rc.c
@@ -87,13 +87,6 @@ int f_append_vcd_hier(const char *str)
     return (0);
 }
 
-int f_atomic_vectors(const char *str)
-{
-    DEBUG(printf("f_atomic_vectors(\"%s\")\n", str));
-    GLOBALS->atomic_vectors = atoi_64(str) ? 1 : 0;
-    return (0);
-}
-
 int f_autoname_bundles(const char *str)
 {
     DEBUG(printf("f_autoname_bundles(\"%s\")\n", str));
@@ -828,7 +821,6 @@ static struct rc_entry rcitems[] = {
     {"alt_hier_delimeter", f_alt_hier_delimeter},
     {"analog_redraw_skip_count", f_analog_redraw_skip_count},
     {"append_vcd_hier", f_append_vcd_hier},
-    {"atomic_vectors", f_atomic_vectors},
     {"autocoalesce", f_autocoalesce},
     {"autocoalesce_reversal", f_autocoalesce_reversal},
     {"autoname_bundles", f_autoname_bundles},

--- a/src/rc.h
+++ b/src/rc.h
@@ -31,7 +31,6 @@ int get_rgb_from_name(const char *str);
 int f_accel(const char *str);
 int f_alt_hier_delimeter(const char *str);
 int f_append_vcd_hier(const char *str);
-int f_atomic_vectors(const char *str);
 int f_autocoalesce(const char *str);
 int f_autocoalesce_reversal(const char *str);
 int f_autoname_bundles(const char *str);

--- a/src/rc.h
+++ b/src/rc.h
@@ -110,7 +110,6 @@ int f_use_full_precision(const char *str);
 int f_use_maxtime_display(const char *str);
 int f_use_nonprop_fonts(const char *str);
 int f_use_roundcaps(const char *str);
-int f_vcd_explicit_zero_subscripts(const char *str);
 int f_vcd_preserve_glitches(const char *str);
 int f_vcd_warning_filesize(const char *str);
 int f_vector_padding(const char *str);

--- a/src/search.c
+++ b/src/search.c
@@ -200,58 +200,6 @@ static void on_changed(GtkComboBox *widget, gpointer user_data)
 
 /* call cleanup() on ok/insert functions */
 
-static void bundle_cleanup(GtkWidget *widget, gpointer data)
-{
-    (void)widget;
-    (void)data;
-
-    if (GLOBALS->entrybox_text_local_search_c_2) {
-        char *efix;
-
-        efix = GLOBALS->entrybox_text_local_search_c_2;
-        while (*efix) {
-            if (*efix == ' ') {
-                *efix = '_';
-            }
-            efix++;
-        }
-
-        DEBUG(printf("Bundle name is: %s\n", GLOBALS->entrybox_text_local_search_c_2));
-        add_vector_selected(GLOBALS->entrybox_text_local_search_c_2,
-                            GLOBALS->selected_rows_search_c_2,
-                            GLOBALS->bundle_direction_search_c_2);
-        free_2(GLOBALS->entrybox_text_local_search_c_2);
-    }
-
-    redraw_signals_and_waves();
-}
-
-static void bundle_callback_generic(void)
-{
-    DEBUG(printf("Selected_rows: %d\n", GLOBALS->selected_rows_search_c_2));
-    if (GLOBALS->selected_rows_search_c_2 > 0) {
-        entrybox_local("Enter Bundle Name", 300, "", 128, G_CALLBACK(bundle_cleanup));
-    }
-}
-
-static void bundle_callback_up(GtkWidget *widget, gpointer data)
-{
-    (void)widget;
-    (void)data;
-
-    GLOBALS->bundle_direction_search_c_2 = 0;
-    bundle_callback_generic();
-}
-
-static void bundle_callback_down(GtkWidget *widget, gpointer data)
-{
-    (void)widget;
-    (void)data;
-
-    GLOBALS->bundle_direction_search_c_2 = 1;
-    bundle_callback_generic();
-}
-
 static void insert_callback(GtkWidget *widget, GtkWidget *nothing)
 {
     (void)nothing;
@@ -723,7 +671,6 @@ void search_enter_callback(GtkWidget *widget, GtkWidget *do_warning)
     int i;
     char *s, *tmp2;
     gfloat interval;
-    int depack_cnt = 0;
     char *duplicate_row_buffer = NULL;
 
     if (GLOBALS->is_searching_running_search_c_1)
@@ -788,8 +735,6 @@ void search_enter_callback(GtkWidget *widget, GtkWidget *do_warning)
             skiprow = 0;
             strcpy(duplicate_row_buffer, hfacname);
         }
-
-        depack_cnt += was_packed;
 
         if ((!skiprow) && wave_regex_match(hfacname, WAVE_REGEX_SEARCH))
             if ((!GLOBALS->is_ghw) || (strcmp(WAVE_GHW_DUMMYFACNAME, hfacname))) {
@@ -1071,28 +1016,6 @@ void searchbox(const char *title, GCallback func)
         insert_button,
         "Add selected signals after last highlighted signal on the main window.");
     gtk_box_pack_start(GTK_BOX(button_box2), insert_button, TRUE, TRUE, 0);
-
-    if (GLOBALS->vcd_explicit_zero_subscripts >= 0) {
-        GtkWidget *bundle_up_button = gtk_button_new_with_label("Bundle Up");
-        gtkwave_signal_connect_object(bundle_up_button,
-                                      "clicked",
-                                      G_CALLBACK(bundle_callback_up),
-                                      GLOBALS->window_search_c_7);
-        gtk_tooltips_set_tip_2(bundle_up_button,
-                               "Bundle selected signals into a single bit vector with the topmost "
-                               "selected signal as the LSB and the lowest as the MSB.");
-        gtk_box_pack_start(GTK_BOX(button_box2), bundle_up_button, TRUE, TRUE, 0);
-
-        GtkWidget *bundle_down_button = gtk_button_new_with_label("Bundle Down");
-        gtkwave_signal_connect_object(bundle_down_button,
-                                      "clicked",
-                                      G_CALLBACK(bundle_callback_down),
-                                      GLOBALS->window_search_c_7);
-        gtk_tooltips_set_tip_2(bundle_down_button,
-                               "Bundle selected signals into a single bit vector with the topmost "
-                               "selected signal as the MSB and the lowest as the LSB.");
-        gtk_box_pack_start(GTK_BOX(button_box2), bundle_down_button, TRUE, TRUE, 0);
-    }
 
     GtkWidget *replace_button = gtk_button_new_with_label("Replace");
     gtkwave_signal_connect_object(replace_button,

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -233,11 +233,9 @@ static struct symbol *symfind_2(char *s, unsigned int *rows_return)
             int i;
             int mat;
 
-#ifndef WAVE_HIERFIX
             if (!GLOBALS->escaped_names_found_vcd_c_1) {
                 return (sr);
             }
-#endif
 
             if (GLOBALS->facs_have_symbols_state_machine == 0) {
                 if (GLOBALS->escaped_names_found_vcd_c_1) {

--- a/src/symbol.h
+++ b/src/symbol.h
@@ -101,7 +101,6 @@ int maketraces(char *, char *, int);
 /* additions to bitvec.c because of search.c/menu.c ==> formerly in analyzer.h */
 bvptr bits2vector(struct Bits *b);
 struct Bits *makevec_selected(char *vec, int numrows, char direction);
-int add_vector_selected(char *alias, int numrows, char direction);
 struct Bits *makevec_range(char *vec, int lo, int hi, char direction);
 int add_vector_range(char *alias, int lo, int hi, char direction);
 struct Bits *makevec_chain(char *vec, struct symbol *sym, int len);

--- a/src/vcd.c
+++ b/src/vcd.c
@@ -1322,8 +1322,7 @@ static void vcd_parse(void)
 
                     v = (struct vcdsymbol *)calloc_2(1, sizeof(struct vcdsymbol));
                     v->vartype = vtok;
-                    v->msi = v->lsi =
-                        GLOBALS->vcd_explicit_zero_subscripts; /* indicate [un]subscripted status */
+                    v->msi = v->lsi = -1;
 
                     if (vtok == V_PORT) {
                         vtok = get_vartoken(1);
@@ -1634,17 +1633,7 @@ static void vcd_parse(void)
                                 fprintf(GLOBALS->vcd_save_handle, "%s\n", v->name);
                             } else {
                                 if (v->msi >= 0) {
-                                    if (!GLOBALS->vcd_explicit_zero_subscripts)
-                                        fprintf(GLOBALS->vcd_save_handle,
-                                                "%s%c%d\n",
-                                                v->name,
-                                                GLOBALS->hier_delimeter,
-                                                v->msi);
-                                    else
-                                        fprintf(GLOBALS->vcd_save_handle,
-                                                "%s[%d]\n",
-                                                v->name,
-                                                v->msi);
+                                    fprintf(GLOBALS->vcd_save_handle, "%s[%d]\n", v->name, v->msi);
                                 } else {
                                     fprintf(GLOBALS->vcd_save_handle, "%s\n", v->name);
                                 }
@@ -2247,10 +2236,7 @@ static void vcd_build_symbols(void)
 
                 for (j = 0; j < v->size; j++) {
                     if (v->msi >= 0) {
-                        if (!GLOBALS->vcd_explicit_zero_subscripts)
-                            sprintf(str + slen, "%d", msi);
-                        else
-                            sprintf(str + slen - 1, "[%d]", msi);
+                        sprintf(str + slen - 1, "[%d]", msi);
                     }
 
                     hashdirty = 0;

--- a/src/vcd.c
+++ b/src/vcd.c
@@ -2525,9 +2525,6 @@ void vcd_sortfacs(void)
     GLOBALS->curnode = GLOBALS->firstnode;
     for (i = 0; i < GLOBALS->numfacs; i++) {
         char *subst;
-#ifdef WAVE_HIERFIX
-        char ch;
-#endif
         int len;
         struct symchain *sc;
 
@@ -2538,38 +2535,12 @@ void vcd_sortfacs(void)
         sc = GLOBALS->curnode;
         GLOBALS->curnode = GLOBALS->curnode->next;
         free_2(sc);
-#ifdef WAVE_HIERFIX
-        while ((ch = (*subst))) {
-            if (ch == GLOBALS->hier_delimeter) {
-                *subst = VCDNAM_HIERSORT;
-            } /* forces sort at hier boundaries */
-            subst++;
-        }
-#endif
     }
     GLOBALS->firstnode = GLOBALS->curnode = NULL;
 
     /* quicksort(facs,0,numfacs-1); */ /* quicksort deprecated because it degenerates on sorted
                                           traces..badly.  very badly. */
     wave_heapsort(GLOBALS->facs, GLOBALS->numfacs);
-
-#ifdef WAVE_HIERFIX
-    for (i = 0; i < GLOBALS->numfacs; i++) {
-        char *subst, ch;
-
-        subst = GLOBALS->facs[i]->name;
-        while ((ch = (*subst))) {
-            if (ch == VCDNAM_HIERSORT) {
-                *subst = GLOBALS->hier_delimeter;
-            } /* restore back to normal */
-            subst++;
-        }
-
-#ifdef DEBUG_FACILITIES
-        printf("%-4d %s\n", i, facs[i]->name);
-#endif
-    }
-#endif
 
     GLOBALS->facs_are_sorted = 1;
 

--- a/src/vcd.c
+++ b/src/vcd.c
@@ -885,7 +885,7 @@ static void parse_valuechange(void)
                 }
                 DEBUG(fprintf(stderr, "%s = '%s'\n", v->name, v->value));
 
-                if ((v->size == 1) || (!GLOBALS->atomic_vectors)) {
+                if (v->size == 1) {
                     int i;
                     for (i = 0; i < v->size; i++) {
                         add_histent(GLOBALS->current_time_vcd_c_1,
@@ -981,7 +981,7 @@ static void parse_valuechange(void)
                 }
                 DEBUG(fprintf(stderr, "%s = '%s'\n", v->name, v->value));
 
-                if ((v->size == 1) || (!GLOBALS->atomic_vectors)) {
+                if (v->size == 1) {
                     int i;
                     for (i = 0; i < v->size; i++) {
                         add_histent(GLOBALS->current_time_vcd_c_1,
@@ -1611,28 +1611,13 @@ static void vcd_parse(void)
                     v->narray = (struct Node **)calloc_2(v->size, sizeof(struct Node *));
                     {
                         int i;
-                        if (GLOBALS->atomic_vectors) {
-                            for (i = 0; i < v->size; i++) {
-                                v->value[i] = 'x';
-                            }
-                            v->narray[0] = (struct Node *)calloc_2(1, sizeof(struct Node));
-                            v->narray[0]->head.time = -1;
-                            v->narray[0]->head.v.h_val = AN_X;
-                            set_vcd_vartype(v, v->narray[0]);
-                        } else {
-                            for (i = 0; i < v->size; i++) {
-                                v->value[i] = 'x';
-
-                                v->narray[i] = (struct Node *)calloc_2(1, sizeof(struct Node));
-                                v->narray[i]->head.time = -1;
-                                v->narray[i]->head.v.h_val = AN_X;
-                                if (i == 0) {
-                                    set_vcd_vartype(v, v->narray[0]);
-                                } else {
-                                    v->narray[i]->vartype = v->narray[0]->vartype;
-                                }
-                            }
+                        for (i = 0; i < v->size; i++) {
+                            v->value[i] = 'x';
                         }
+                        v->narray[0] = (struct Node *)calloc_2(1, sizeof(struct Node));
+                        v->narray[0]->head.time = -1;
+                        v->narray[0]->head.v.h_val = AN_X;
+                        set_vcd_vartype(v, v->narray[0]);
                     }
 
                     if (!GLOBALS->vcdsymroot_vcd_c_1) {
@@ -1665,51 +1650,11 @@ static void vcd_parse(void)
                                 }
                             }
                         } else {
-                            int i;
-
-                            if (!GLOBALS->atomic_vectors) {
-                                fprintf(GLOBALS->vcd_save_handle,
-                                        "#%s[%d:%d]",
-                                        v->name,
-                                        v->msi,
-                                        v->lsi);
-                                if (v->msi > v->lsi) {
-                                    for (i = v->msi; i >= v->lsi; i--) {
-                                        if (!GLOBALS->vcd_explicit_zero_subscripts)
-                                            fprintf(GLOBALS->vcd_save_handle,
-                                                    " %s%c%d",
-                                                    v->name,
-                                                    GLOBALS->hier_delimeter,
-                                                    i);
-                                        else
-                                            fprintf(GLOBALS->vcd_save_handle,
-                                                    " %s[%d]",
-                                                    v->name,
-                                                    i);
-                                    }
-                                } else {
-                                    for (i = v->msi; i <= v->lsi; i++) {
-                                        if (!GLOBALS->vcd_explicit_zero_subscripts)
-                                            fprintf(GLOBALS->vcd_save_handle,
-                                                    " %s%c%d",
-                                                    v->name,
-                                                    GLOBALS->hier_delimeter,
-                                                    i);
-                                        else
-                                            fprintf(GLOBALS->vcd_save_handle,
-                                                    " %s[%d]",
-                                                    v->name,
-                                                    i);
-                                    }
-                                }
-                                fprintf(GLOBALS->vcd_save_handle, "\n");
-                            } else {
-                                fprintf(GLOBALS->vcd_save_handle,
-                                        "%s[%d:%d]\n",
-                                        v->name,
-                                        v->msi,
-                                        v->lsi);
-                            }
+                            fprintf(GLOBALS->vcd_save_handle,
+                                    "%s[%d:%d]\n",
+                                    v->name,
+                                    v->msi,
+                                    v->lsi);
                         }
                     }
 
@@ -2212,7 +2157,7 @@ static void add_tail_histents(void)
             d = malloc_2(sizeof(double));
             *d = 1.0;
             add_histent(MAX_HISTENT_TIME - 1, v->narray[0], 'g', 0, (char *)d);
-        } else if ((v->size == 1) || (!GLOBALS->atomic_vectors))
+        } else if (v->size == 1)
             for (j = 0; j < v->size; j++) {
                 add_histent(MAX_HISTENT_TIME - 1, v->narray[j], 'x', 0, NULL);
             }
@@ -2235,7 +2180,7 @@ static void add_tail_histents(void)
             d = malloc_2(sizeof(double));
             *d = 0.0;
             add_histent(MAX_HISTENT_TIME, v->narray[0], 'g', 0, (char *)d);
-        } else if ((v->size == 1) || (!GLOBALS->atomic_vectors))
+        } else if (v->size == 1)
             for (j = 0; j < v->size; j++) {
                 add_histent(MAX_HISTENT_TIME, v->narray[j], 'z', 0, NULL);
             }
@@ -2297,8 +2242,7 @@ static void vcd_build_symbols(void)
                 }
             }
 
-            if (((v->size == 1) || (!GLOBALS->atomic_vectors)) && (v->vartype != V_REAL) &&
-                (v->vartype != V_STRINGTYPE)) {
+            if ((v->size == 1) && (v->vartype != V_REAL) && (v->vartype != V_STRINGTYPE)) {
                 struct symbol *s = NULL;
 
                 for (j = 0; j < v->size; j++) {

--- a/src/vcd.h
+++ b/src/vcd.h
@@ -48,9 +48,6 @@
 enum VCDName_ByteSubstitutions
 {
     VCDNAM_NULL = 0,
-#ifdef WAVE_HIERFIX
-    VCDNAM_HIERSORT,
-#endif
     VCDNAM_ESCAPE
 };
 

--- a/src/vcd_partial.c
+++ b/src/vcd_partial.c
@@ -839,7 +839,7 @@ static void parse_valuechange(void)
                 }
                 DEBUG(fprintf(stderr, "%s = '%s'\n", v->name, v->value));
 
-                if ((v->size == 1) || (!GLOBALS->atomic_vectors)) {
+                if (v->size == 1) {
                     int i;
                     for (i = 0; i < v->size; i++) {
                         v->narray[i]->curr = v->app_array[i];
@@ -964,7 +964,7 @@ static void parse_valuechange(void)
                 }
                 DEBUG(fprintf(stderr, "%s = '%s'\n", v->name, v->value));
 
-                if ((v->size == 1) || (!GLOBALS->atomic_vectors)) {
+                if (v->size == 1) {
                     int i;
                     for (i = 0; i < v->size; i++) {
                         v->narray[i]->curr = v->app_array[i];
@@ -1640,22 +1640,12 @@ static void vcd_parse(void)
                     v->app_array = (hptr *)calloc_2(v->size, sizeof(hptr));
                     {
                         int i;
-                        if (GLOBALS->atomic_vectors) {
-                            for (i = 0; i < v->size; i++) {
-                                v->value[i] = 'x';
-                            }
-                            v->narray[0] = (struct Node *)calloc_2(1, sizeof(struct Node));
-                            v->narray[0]->head.time = -1;
-                            v->narray[0]->head.v.h_val = AN_X;
-                        } else {
-                            for (i = 0; i < v->size; i++) {
-                                v->value[i] = 'x';
-
-                                v->narray[i] = (struct Node *)calloc_2(1, sizeof(struct Node));
-                                v->narray[i]->head.time = -1;
-                                v->narray[i]->head.v.h_val = AN_X;
-                            }
+                        for (i = 0; i < v->size; i++) {
+                            v->value[i] = 'x';
                         }
+                        v->narray[0] = (struct Node *)calloc_2(1, sizeof(struct Node));
+                        v->narray[0]->head.time = -1;
+                        v->narray[0]->head.v.h_val = AN_X;
                     }
 
                     if (!GLOBALS->vcdsymroot_vcd_partial_c_2) {
@@ -2068,7 +2058,7 @@ static void add_tail_histents(void)
             set_vcd_vartype(v, v->narray[0]);
             v->app_array[0] = rc;
             v->tr_array[0] = v->narray[0]->curr;
-        } else if ((v->size == 1) || (!GLOBALS->atomic_vectors))
+        } else if (v->size == 1)
             for (j = 0; j < v->size; j++) {
                 rc = add_histent_p(MAX_HISTENT_TIME - 1, v->narray[j], 'x', 0, NULL);
                 set_vcd_vartype(v, v->narray[j]);
@@ -2097,7 +2087,7 @@ static void add_tail_histents(void)
             d = malloc_2(sizeof(double));
             *d = 0.0;
             add_histent_p(MAX_HISTENT_TIME, v->narray[0], 'g', 0, (char *)d);
-        } else if ((v->size == 1) || (!GLOBALS->atomic_vectors))
+        } else if (v->size == 1)
             for (j = 0; j < v->size; j++) {
                 add_histent_p(MAX_HISTENT_TIME, v->narray[j], 'z', 0, NULL);
             }
@@ -2163,8 +2153,7 @@ static void vcd_build_symbols(void)
                 }
             }
 
-            if (((v->size == 1) || (!GLOBALS->atomic_vectors)) && (v->vartype != V_REAL) &&
-                (v->vartype != V_STRINGTYPE)) {
+            if (((v->size == 1)) && (v->vartype != V_REAL) && (v->vartype != V_STRINGTYPE)) {
                 struct symbol *s = NULL;
 
                 for (j = 0; j < v->size; j++) {

--- a/src/vcd_partial.c
+++ b/src/vcd_partial.c
@@ -1345,8 +1345,7 @@ static void vcd_parse(void)
 
                     v = (struct vcdsymbol *)calloc_2(1, sizeof(struct vcdsymbol));
                     v->vartype = vtok;
-                    v->msi = v->lsi =
-                        GLOBALS->vcd_explicit_zero_subscripts; /* indicate [un]subscripted status */
+                    v->msi = v->lsi = -1;
 
                     if (vtok == V_PORT) {
                         vtok = get_vartoken(1);
@@ -2158,10 +2157,7 @@ static void vcd_build_symbols(void)
 
                 for (j = 0; j < v->size; j++) {
                     if (v->msi >= 0) {
-                        if (!GLOBALS->vcd_explicit_zero_subscripts)
-                            sprintf(str + slen, "%d", msi);
-                        else
-                            sprintf(str + slen - 1, "[%d]", msi);
+                        sprintf(str + slen - 1, "[%d]", msi);
                     }
 
                     hashdirty = 0;

--- a/src/vcd_recoder.c
+++ b/src/vcd_recoder.c
@@ -1785,8 +1785,7 @@ static void vcd_parse(void)
 
                     v = (struct vcdsymbol *)calloc_2(1, sizeof(struct vcdsymbol));
                     v->vartype = vtok;
-                    v->msi = v->lsi =
-                        GLOBALS->vcd_explicit_zero_subscripts; /* indicate [un]subscripted status */
+                    v->msi = v->lsi = -1;
 
                     if (vtok == V_PORT) {
                         vtok = get_vartoken(1);
@@ -2096,17 +2095,7 @@ static void vcd_parse(void)
                                 fprintf(GLOBALS->vcd_save_handle, "%s\n", v->name);
                             } else {
                                 if (v->msi >= 0) {
-                                    if (!GLOBALS->vcd_explicit_zero_subscripts)
-                                        fprintf(GLOBALS->vcd_save_handle,
-                                                "%s%c%d\n",
-                                                v->name,
-                                                GLOBALS->hier_delimeter,
-                                                v->msi);
-                                    else
-                                        fprintf(GLOBALS->vcd_save_handle,
-                                                "%s[%d]\n",
-                                                v->name,
-                                                v->msi);
+                                    fprintf(GLOBALS->vcd_save_handle, "%s[%d]\n", v->name, v->msi);
                                 } else {
                                     fprintf(GLOBALS->vcd_save_handle, "%s\n", v->name);
                                 }
@@ -2615,10 +2604,7 @@ static void vcd_build_symbols(void)
 
                 for (j = 0; j < v->size; j++) {
                     if (v->msi >= 0) {
-                        if (!GLOBALS->vcd_explicit_zero_subscripts)
-                            sprintf(str + slen, "%d", msi);
-                        else
-                            sprintf(str + slen - 1, "[%d]", msi);
+                        sprintf(str + slen - 1, "[%d]", msi);
                     }
 
                     hashdirty = 0;

--- a/src/vzt.c
+++ b/src/vzt.c
@@ -313,15 +313,9 @@ TimeType vzt_main(char *fname, char *skip_start, char *skip_end)
             if ((len = strlen(subst = GLOBALS->facs[i]->name)) > GLOBALS->longestname)
                 GLOBALS->longestname = len;
             while ((ch = (*subst))) {
-#ifdef WAVE_HIERFIX
-                if (ch == GLOBALS->hier_delimeter) {
-                    *subst = (!esc) ? VCDNAM_HIERSORT : VCDNAM_ESCAPE;
-                } /* forces sort at hier boundaries */
-#else
                 if ((ch == GLOBALS->hier_delimeter) && (esc)) {
                     *subst = VCDNAM_ESCAPE;
                 } /* forces sort at hier boundaries */
-#endif
                 else if (ch == '\\') {
                     esc = 1;
                     GLOBALS->escaped_names_found_vcd_c_1 = 1;
@@ -333,20 +327,6 @@ TimeType vzt_main(char *fname, char *skip_start, char *skip_end)
         /* SPLASH */ splash_sync(3, 5);
         fprintf(stderr, VZT_RDLOAD "Sorting facilities at hierarchy boundaries.\n");
         wave_heapsort(GLOBALS->facs, GLOBALS->numfacs);
-
-#ifdef WAVE_HIERFIX
-        for (i = 0; i < GLOBALS->numfacs; i++) {
-            char *subst, ch;
-
-            subst = GLOBALS->facs[i]->name;
-            while ((ch = (*subst))) {
-                if (ch == VCDNAM_HIERSORT) {
-                    *subst = GLOBALS->hier_delimeter;
-                } /* restore back to normal */
-                subst++;
-            }
-        }
-#endif
 
         GLOBALS->facs_are_sorted = 1;
 

--- a/src/vzt.c
+++ b/src/vzt.c
@@ -214,150 +214,94 @@ TimeType vzt_main(char *fname, char *skip_start, char *skip_end)
     /* SPLASH */ splash_sync(2, 5);
     GLOBALS->facs = (struct symbol **)malloc_2(GLOBALS->numfacs * sizeof(struct symbol *));
 
-    if (GLOBALS->fast_tree_sort) {
-        for (i = 0; i < GLOBALS->numfacs; i++) {
-            int len;
-            GLOBALS->facs[i] = &sym_block[i];
-            if ((len = strlen(GLOBALS->facs[i]->name)) > GLOBALS->longestname)
-                GLOBALS->longestname = len;
-        }
+    for (i = 0; i < GLOBALS->numfacs; i++) {
+        int len;
+        GLOBALS->facs[i] = &sym_block[i];
+        if ((len = strlen(GLOBALS->facs[i]->name)) > GLOBALS->longestname)
+            GLOBALS->longestname = len;
+    }
 
-        if (numalias) {
-            int idx_lft = 0;
-            int idx_lftmax = GLOBALS->numfacs - numalias;
-            int idx_rgh = GLOBALS->numfacs - numalias;
-            struct symbol **facs_merge =
-                (struct symbol **)malloc_2(GLOBALS->numfacs * sizeof(struct symbol *));
+    if (numalias) {
+        int idx_lft = 0;
+        int idx_lftmax = GLOBALS->numfacs - numalias;
+        int idx_rgh = GLOBALS->numfacs - numalias;
+        struct symbol **facs_merge =
+            (struct symbol **)malloc_2(GLOBALS->numfacs * sizeof(struct symbol *));
 
-            fprintf(stderr, VZT_RDLOAD "Merging in %d aliases.\n", numalias);
+        fprintf(stderr, VZT_RDLOAD "Merging in %d aliases.\n", numalias);
 
-            for (i = 0; i < GLOBALS->numfacs; i++) /* fix possible tail appended aliases by
-                                                      remerging in partial one pass merge sort */
-            {
-                if (strcmp(GLOBALS->facs[idx_lft]->name, GLOBALS->facs[idx_rgh]->name) <= 0) {
-                    facs_merge[i] = GLOBALS->facs[idx_lft++];
+        for (i = 0; i < GLOBALS->numfacs; i++) /* fix possible tail appended aliases by
+                                                  remerging in partial one pass merge sort */
+        {
+            if (strcmp(GLOBALS->facs[idx_lft]->name, GLOBALS->facs[idx_rgh]->name) <= 0) {
+                facs_merge[i] = GLOBALS->facs[idx_lft++];
 
-                    if (idx_lft == idx_lftmax) {
-                        for (i++; i < GLOBALS->numfacs; i++) {
-                            facs_merge[i] = GLOBALS->facs[idx_rgh++];
-                        }
+                if (idx_lft == idx_lftmax) {
+                    for (i++; i < GLOBALS->numfacs; i++) {
+                        facs_merge[i] = GLOBALS->facs[idx_rgh++];
                     }
-                } else {
-                    facs_merge[i] = GLOBALS->facs[idx_rgh++];
+                }
+            } else {
+                facs_merge[i] = GLOBALS->facs[idx_rgh++];
 
-                    if (idx_rgh == GLOBALS->numfacs) {
-                        for (i++; i < GLOBALS->numfacs; i++) {
-                            facs_merge[i] = GLOBALS->facs[idx_lft++];
-                        }
+                if (idx_rgh == GLOBALS->numfacs) {
+                    for (i++; i < GLOBALS->numfacs; i++) {
+                        facs_merge[i] = GLOBALS->facs[idx_lft++];
                     }
                 }
             }
-
-            free_2(GLOBALS->facs);
-            GLOBALS->facs = facs_merge;
         }
 
-        /* SPLASH */ splash_sync(3, 5);
-        fprintf(stderr, VZT_RDLOAD "Building facility hierarchy tree.\n");
+        free_2(GLOBALS->facs);
+        GLOBALS->facs = facs_merge;
+    }
 
-        init_tree();
-        for (i = 0; i < GLOBALS->numfacs; i++) {
-            int esc = 0;
-            char *subst = GLOBALS->facs[i]->name;
-            char ch;
+    /* SPLASH */ splash_sync(3, 5);
+    fprintf(stderr, VZT_RDLOAD "Building facility hierarchy tree.\n");
 
-            while ((ch = (*subst))) {
-                if (ch == GLOBALS->hier_delimeter) {
-                    if (esc)
-                        *subst = VCDNAM_ESCAPE;
-                } else if (ch == '\\') {
-                    esc = 1;
-                    GLOBALS->escaped_names_found_vcd_c_1 = 1;
-                }
-                subst++;
+    init_tree();
+    for (i = 0; i < GLOBALS->numfacs; i++) {
+        int esc = 0;
+        char *subst = GLOBALS->facs[i]->name;
+        char ch;
+
+        while ((ch = (*subst))) {
+            if (ch == GLOBALS->hier_delimeter) {
+                if (esc)
+                    *subst = VCDNAM_ESCAPE;
+            } else if (ch == '\\') {
+                esc = 1;
+                GLOBALS->escaped_names_found_vcd_c_1 = 1;
             }
-
-            build_tree_from_name(GLOBALS->facs[i]->name, i);
-        }
-        /* SPLASH */ splash_sync(4, 5);
-        if (GLOBALS->escaped_names_found_vcd_c_1) {
-            for (i = 0; i < GLOBALS->numfacs; i++) {
-                char *subst, ch;
-                subst = GLOBALS->facs[i]->name;
-                while ((ch = (*subst))) {
-                    if (ch == VCDNAM_ESCAPE) {
-                        *subst = GLOBALS->hier_delimeter;
-                    } /* restore back to normal */
-                    subst++;
-                }
-            }
-        }
-        treegraft(&GLOBALS->treeroot);
-
-        fprintf(stderr, VZT_RDLOAD "Sorting facility hierarchy tree.\n");
-        treesort(GLOBALS->treeroot, NULL);
-        /* SPLASH */ splash_sync(5, 5);
-        order_facs_from_treesort(GLOBALS->treeroot, &GLOBALS->facs);
-        if (GLOBALS->escaped_names_found_vcd_c_1) {
-            treenamefix(GLOBALS->treeroot);
+            subst++;
         }
 
-        GLOBALS->facs_are_sorted = 1;
-    } else {
+        build_tree_from_name(GLOBALS->facs[i]->name, i);
+    }
+    /* SPLASH */ splash_sync(4, 5);
+    if (GLOBALS->escaped_names_found_vcd_c_1) {
         for (i = 0; i < GLOBALS->numfacs; i++) {
             char *subst, ch;
-            int len;
-            int esc = 0;
-
-            GLOBALS->facs[i] = &sym_block[i];
-            if ((len = strlen(subst = GLOBALS->facs[i]->name)) > GLOBALS->longestname)
-                GLOBALS->longestname = len;
+            subst = GLOBALS->facs[i]->name;
             while ((ch = (*subst))) {
-                if ((ch == GLOBALS->hier_delimeter) && (esc)) {
-                    *subst = VCDNAM_ESCAPE;
-                } /* forces sort at hier boundaries */
-                else if (ch == '\\') {
-                    esc = 1;
-                    GLOBALS->escaped_names_found_vcd_c_1 = 1;
-                }
+                if (ch == VCDNAM_ESCAPE) {
+                    *subst = GLOBALS->hier_delimeter;
+                } /* restore back to normal */
                 subst++;
             }
         }
-
-        /* SPLASH */ splash_sync(3, 5);
-        fprintf(stderr, VZT_RDLOAD "Sorting facilities at hierarchy boundaries.\n");
-        wave_heapsort(GLOBALS->facs, GLOBALS->numfacs);
-
-        GLOBALS->facs_are_sorted = 1;
-
-        /* SPLASH */ splash_sync(4, 5);
-        fprintf(stderr, VZT_RDLOAD "Building facility hierarchy tree.\n");
-
-        init_tree();
-        for (i = 0; i < GLOBALS->numfacs; i++) {
-            char *nf = GLOBALS->facs[i]->name;
-            build_tree_from_name(nf, i);
-        }
-        /* SPLASH */ splash_sync(5, 5);
-        if (GLOBALS->escaped_names_found_vcd_c_1) {
-            for (i = 0; i < GLOBALS->numfacs; i++) {
-                char *subst, ch;
-                subst = GLOBALS->facs[i]->name;
-                while ((ch = (*subst))) {
-                    if (ch == VCDNAM_ESCAPE) {
-                        *subst = GLOBALS->hier_delimeter;
-                    } /* restore back to normal */
-                    subst++;
-                }
-            }
-        }
-
-        treegraft(&GLOBALS->treeroot);
-        treesort(GLOBALS->treeroot, NULL);
-        if (GLOBALS->escaped_names_found_vcd_c_1) {
-            treenamefix(GLOBALS->treeroot);
-        }
     }
+    treegraft(&GLOBALS->treeroot);
+
+    fprintf(stderr, VZT_RDLOAD "Sorting facility hierarchy tree.\n");
+    treesort(GLOBALS->treeroot, NULL);
+    /* SPLASH */ splash_sync(5, 5);
+    order_facs_from_treesort(GLOBALS->treeroot, &GLOBALS->facs);
+    if (GLOBALS->escaped_names_found_vcd_c_1) {
+        treenamefix(GLOBALS->treeroot);
+    }
+
+    GLOBALS->facs_are_sorted = 1;
 
     GLOBALS->min_time = GLOBALS->first_cycle_vzt_c_3;
     GLOBALS->max_time = GLOBALS->last_cycle_vzt_c_3;


### PR DESCRIPTION
This PR removes an old unused ifdef, a global variable, and two rc variables. All of them were previously discussed in different issues and they should all be obsolete and safe to remove.