### PR TITLE
Change type of GLOBALS->preg_regex_c_1

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -639,7 +639,7 @@ struct Global
     /*
      * regex.c
      */
-    struct re_pattern_buffer *preg_regex_c_1; /* from regex.c 339 */
+    regex_t *preg_regex_c_1; /* from regex.c 339 */
     int *regex_ok_regex_c_1; /* from regex.c 340 */
 
 /*


### PR DESCRIPTION
This PR changes the type of `GLOBALS->preg_regex_c_1` to fix issues in Windows and macOS. All functions that uses this variable expect `regex_t` as an argument and it also allocated to a size of `sizeof(regex_t)`.