### PR TITLE
Fix compilation on older GCC versions

### DIFF
--- a/lib/libgtkwave/src/gw-color.c
+++ b/lib/libgtkwave/src/gw-color.c
@@ -7,9 +7,8 @@ typedef struct
 } X11Color;
 
 #define X11_CONST(name, r, g, b) \
-    (X11Color) \
     { \
-        name, (GwColor) \
+        name, \
         { \
             r / 255.0, g / 255.0, b / 255.0, 1.0 \
         } \


### PR DESCRIPTION
Older GCC versions (< version 13) didn't like the casts inside the code generated by the `X11_CONST` macro.