### PR TITLE
Add GwStems to libgtkwave

### DIFF
--- a/lib/libgtkwave/src/gtkwave.h
+++ b/lib/libgtkwave/src/gtkwave.h
@@ -16,3 +16,4 @@
 #include "gw-bits.h"
 #include "gw-bit-vector.h"
 #include "gw-trace.h"
+#include "gw-stems.h"

--- a/lib/libgtkwave/src/gw-stems.c
+++ b/lib/libgtkwave/src/gw-stems.c
@@ -1,0 +1,153 @@
+#include "gw-stems.h"
+
+typedef struct
+{
+    guint32 path_index;
+    guint32 line_number;
+} GwStemInternal;
+
+static const GwStem ERROR_STEM = {
+    .path = "ERROR",
+    .line_number = 0,
+};
+
+struct _GwStems
+{
+    GObject parent_instance;
+
+    GPtrArray *paths;
+    GArray *stems;
+    GArray *istems;
+};
+
+G_DEFINE_TYPE(GwStems, gw_stems, G_TYPE_OBJECT)
+
+static void gw_stems_finalize(GObject *object)
+{
+    GwStems *self = GW_STEMS(object);
+
+    g_ptr_array_free(self->paths, TRUE);
+    g_array_free(self->stems, TRUE);
+    g_array_free(self->istems, TRUE);
+
+    G_OBJECT_CLASS(gw_stems_parent_class)->finalize(object);
+}
+
+static void gw_stems_class_init(GwStemsClass *klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS(klass);
+
+    object_class->finalize = gw_stems_finalize;
+}
+
+static void gw_stems_init(GwStems *self)
+{
+    self->paths = g_ptr_array_new_with_free_func(g_free);
+    self->stems = g_array_new(FALSE, FALSE, sizeof(GwStemInternal));
+    self->istems = g_array_new(FALSE, FALSE, sizeof(GwStemInternal));
+}
+
+GwStems *gw_stems_new(void)
+{
+    return g_object_new(GW_TYPE_STEMS, NULL);
+}
+
+void gw_stems_shrink_to_fit(GwStems *self)
+{
+    g_return_if_fail(GW_IS_STEMS(self));
+
+    g_ptr_array_set_size(self->paths, self->paths->len);
+    g_array_set_size(self->stems, self->stems->len);
+    g_array_set_size(self->istems, self->istems->len);
+}
+
+guint32 gw_stems_add_path(GwStems *self, const gchar *path)
+{
+    g_return_val_if_fail(GW_IS_STEMS(self), 0);
+
+    g_ptr_array_add(self->paths, g_strdup(path));
+
+    return self->paths->len;
+}
+
+static guint32 add_stem_common(GArray *array, guint32 path_index, guint32 line_number)
+{
+    GwStemInternal stem = (GwStemInternal){
+        .path_index = path_index,
+        .line_number = line_number,
+
+    };
+    g_array_append_val(array, stem);
+
+    return array->len;
+}
+
+guint32 gw_stems_add_stem(GwStems *self, guint32 path_index, guint32 line_number)
+{
+    g_return_val_if_fail(GW_IS_STEMS(self), 0);
+
+    return add_stem_common(self->stems, path_index, line_number);
+}
+
+guint32 gw_stems_add_istem(GwStems *self, guint32 path_index, guint32 line_number)
+{
+    g_return_val_if_fail(GW_IS_STEMS(self), 0);
+
+    return add_stem_common(self->istems, path_index, line_number);
+}
+
+GwStem gw_stems_get_common(GwStems *self, GArray *stems, guint32 index)
+{
+    g_return_val_if_fail(index > 0 && index <= stems->len, ERROR_STEM);
+
+    GwStemInternal *stem = &g_array_index(stems, GwStemInternal, index - 1);
+
+    g_return_val_if_fail(gw_stems_is_path_index_valid(self, stem->path_index), ERROR_STEM);
+
+    return (GwStem){
+        .path = g_ptr_array_index(self->paths, stem->path_index - 1),
+        .line_number = stem->line_number,
+    };
+}
+
+GwStem gw_stems_get_stem(GwStems *self, guint32 index)
+{
+    g_return_val_if_fail(GW_IS_STEMS(self), ERROR_STEM);
+
+    return gw_stems_get_common(self, self->stems, index);
+}
+
+GwStem gw_stems_get_istem(GwStems *self, guint32 index)
+{
+    g_return_val_if_fail(GW_IS_STEMS(self), ERROR_STEM);
+
+    return gw_stems_get_common(self, self->istems, index);
+}
+
+gboolean gw_stems_is_path_index_valid(GwStems *self, guint32 path_index)
+{
+    g_return_val_if_fail(GW_IS_STEMS(self), FALSE);
+
+    return path_index > 0 && path_index <= self->paths->len;
+}
+
+guint32 gw_stems_get_next_path_index(GwStems *self)
+{
+    g_return_val_if_fail(GW_IS_STEMS(self), FALSE);
+
+    return self->paths->len + 1;
+}
+
+gboolean gw_stems_is_empty(GwStems *self)
+{
+    g_return_val_if_fail(GW_IS_STEMS(self), TRUE);
+
+    return self->paths->len == 0 || (self->stems->len == 0 && self->istems->len == 0);
+}
+
+gboolean gw_stems_has_istems(GwStems *self)
+{
+    g_return_val_if_fail(GW_IS_STEMS(self), FALSE);
+
+    return self->istems->len != 0;
+}

--- a/lib/libgtkwave/src/gw-stems.h
+++ b/lib/libgtkwave/src/gw-stems.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+typedef struct
+{
+    const char *path;
+    guint32 line_number;
+} GwStem;
+
+#define GW_TYPE_STEMS (gw_stems_get_type())
+G_DECLARE_FINAL_TYPE(GwStems, gw_stems, GW, STEMS, GObject)
+
+GwStems *gw_stems_new(void);
+void gw_stems_shrink_to_fit(GwStems *self);
+
+guint32 gw_stems_add_path(GwStems *self, const gchar *path);
+guint32 gw_stems_add_stem(GwStems *self, guint32 path_index, guint32 line_number);
+guint32 gw_stems_add_istem(GwStems *self, guint32 path_index, guint32 line_number);
+
+GwStem gw_stems_get_stem(GwStems *self, guint32 index);
+GwStem gw_stems_get_istem(GwStems *self, guint32 index);
+
+gboolean gw_stems_is_path_index_valid(GwStems *self, guint32 path_index);
+guint32 gw_stems_get_next_path_index(GwStems *self);
+gboolean gw_stems_is_empty(GwStems *self);
+gboolean gw_stems_has_istems(GwStems *self);
+
+G_END_DECLS

--- a/lib/libgtkwave/src/meson.build
+++ b/lib/libgtkwave/src/meson.build
@@ -4,6 +4,7 @@ libgtkwave_public_sources = [
     'gw-marker.c',
     'gw-named-markers.c',
     'gw-project.c',
+    'gw-stems.c',
     'gw-time.c',
 ]
 
@@ -19,6 +20,7 @@ libgtkwave_public_headers = [
     'gw-marker.h',
     'gw-named-markers.h',
     'gw-project.h',
+    'gw-stems.h',
     'gw-time.h',
     'gw-vector-ent.h',
 ]

--- a/lib/libgtkwave/test/gw-stems.c
+++ b/lib/libgtkwave/test/gw-stems.c
@@ -1,0 +1,116 @@
+#include <gtkwave.h>
+
+static void test_add_stem(void)
+{
+    GwStems *stems = gw_stems_new();
+
+    guint p1 = gw_stems_add_path(stems, "p1");
+    guint p2 = gw_stems_add_path(stems, "p2");
+    g_assert_cmpint(p1, ==, 1);
+    g_assert_cmpint(p2, ==, 2);
+
+    // The first index should be 1, because 0 is used as a marker for no stem
+    g_assert_cmpint(gw_stems_add_stem(stems, p1, 1), ==, 1);
+    g_assert_cmpint(gw_stems_add_stem(stems, p2, 2), ==, 2);
+
+    GwStem stem = gw_stems_get_stem(stems, 1);
+    g_assert_cmpstr(stem.path, ==, "p1");
+    g_assert_cmpint(stem.line_number, ==, 1);
+
+    stem = gw_stems_get_stem(stems, 2);
+    g_assert_cmpstr(stem.path, ==, "p2");
+    g_assert_cmpint(stem.line_number, ==, 2);
+}
+
+static void test_add_istem(void)
+{
+    GwStems *stems = gw_stems_new();
+
+    // Adding stems shouldn't influence the istem indices.
+    guint path2 = gw_stems_add_path(stems, "path2");
+    gw_stems_add_stem(stems, path2, 1);
+    gw_stems_add_stem(stems, path2, 2);
+
+    guint path = gw_stems_add_path(stems, "path");
+
+    // The first index should be 1, because 0 is used as a marker for no stem
+    g_assert_cmpint(gw_stems_add_istem(stems, path, 3), ==, 1);
+    g_assert_cmpint(gw_stems_add_istem(stems, path, 4), ==, 2);
+
+    GwStem stem = gw_stems_get_istem(stems, 1);
+    g_assert_cmpstr(stem.path, ==, "path");
+    g_assert_cmpint(stem.line_number, ==, 3);
+
+    stem = gw_stems_get_istem(stems, 2);
+    g_assert_cmpstr(stem.path, ==, "path");
+    g_assert_cmpint(stem.line_number, ==, 4);
+}
+
+static void test_is_path_index_valid(void)
+{
+    GwStems *stems = gw_stems_new();
+    g_assert_false(gw_stems_is_path_index_valid(stems, 0));
+    g_assert_false(gw_stems_is_path_index_valid(stems, 1));
+    g_assert_false(gw_stems_is_path_index_valid(stems, 2));
+    g_assert_false(gw_stems_is_path_index_valid(stems, 3));
+
+    gw_stems_add_path(stems, "path0");
+    g_assert_false(gw_stems_is_path_index_valid(stems, 0));
+    g_assert_true(gw_stems_is_path_index_valid(stems, 1));
+    g_assert_false(gw_stems_is_path_index_valid(stems, 2));
+    g_assert_false(gw_stems_is_path_index_valid(stems, 3));
+
+    gw_stems_add_path(stems, "path1");
+    g_assert_false(gw_stems_is_path_index_valid(stems, 0));
+    g_assert_true(gw_stems_is_path_index_valid(stems, 1));
+    g_assert_true(gw_stems_is_path_index_valid(stems, 2));
+    g_assert_false(gw_stems_is_path_index_valid(stems, 3));
+}
+
+static void test_get_next_path_index(void)
+{
+    GwStems *stems = gw_stems_new();
+    g_assert_cmpint(gw_stems_get_next_path_index(stems), ==, 1);
+
+    gw_stems_add_path(stems, "path0");
+    g_assert_cmpint(gw_stems_get_next_path_index(stems), ==, 2);
+
+    gw_stems_add_path(stems, "path1");
+    g_assert_cmpint(gw_stems_get_next_path_index(stems), ==, 3);
+}
+
+static void test_is_empty_and_has_istems(void)
+{
+    GwStems *stems = gw_stems_new();
+    g_assert_true(gw_stems_is_empty(stems));
+    g_assert_false(gw_stems_has_istems(stems));
+
+    // stems should still be empty if only a path is added
+    guint p1 = gw_stems_add_path(stems, "p1");
+    g_assert_true(gw_stems_is_empty(stems));
+
+    gw_stems_add_stem(stems, p1, 1);
+    g_assert_false(gw_stems_is_empty(stems));
+    g_assert_false(gw_stems_has_istems(stems));
+
+    stems = gw_stems_new();
+    p1 = gw_stems_add_path(stems, "p1");
+    g_assert_true(gw_stems_is_empty(stems));
+    gw_stems_add_istem(stems, p1, 1);
+    g_assert_false(gw_stems_is_empty(stems));
+    g_assert_true(gw_stems_has_istems(stems));
+    gw_stems_add_stem(stems, p1, 2);
+    g_assert_false(gw_stems_is_empty(stems));
+    g_assert_true(gw_stems_has_istems(stems));
+}
+
+int main(int argc, char *argv[])
+{
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func("/stems/add_stem", test_add_stem);
+    g_test_add_func("/stems/add_istem", test_add_istem);
+    g_test_add_func("/stems/is_path_index_valid", test_is_path_index_valid);
+    g_test_add_func("/stems/get_next_path_index", test_get_next_path_index);
+    g_test_add_func("/stems/is_empty_and_has_istems", test_is_empty_and_has_istems);
+    return g_test_run();
+}

--- a/lib/libgtkwave/test/meson.build
+++ b/lib/libgtkwave/test/meson.build
@@ -4,6 +4,7 @@ libgtkwave_tests = [
     'gw-marker',
     'gw-named-markers',
     'gw-project',
+    'gw-stems',
 ]
 
 foreach test : libgtkwave_tests

--- a/src/globals.c
+++ b/src/globals.c
@@ -62,6 +62,7 @@ struct Global *GLOBALS = NULL;
 /* make this const so if we try to write to it we coredump */
 static const struct Global globals_base_values = {
     NULL, // project
+    NULL, // stems
 
     /*
      * analyzer.c
@@ -236,19 +237,8 @@ static const struct Global globals_base_values = {
     NULL, /* subvar_pnt */
     0, /* fst_filetype */
     0, /* subvar_jrb_count_locked */
-    0, /* stem_file_idx */
-    0, /* stem_line_number */
-    NULL, /* stem_path_string_table */
-    NULL, /* stem_struct_base */
-    NULL, /* istem_struct_base */
-    0, /* stem_path_string_table_siz */
-    0, /* stem_path_string_table_alloc */
-    0, /* stem_struct_base_siz */
-    0, /* stem_struct_base_siz_alloc */
-    0, /* istem_struct_base_siz */
-    0, /* istem_struct_base_siz_alloc */
-    0, /* stem_valid  */
-    0, /* istem_valid */
+    0, /* next_var_stem */
+    0, /* next_var_istem */
     NULL, /* fst_synclock_str */
     NULL, /* synclock_jrb */
     NULL, /* xl_enum_filter */

--- a/src/globals.h
+++ b/src/globals.h
@@ -74,6 +74,7 @@
 struct Global
 {
     GwProject *project;
+    GwStems *stems;
 
     /*
      * analyzer.c
@@ -244,19 +245,8 @@ struct Global
     char **subvar_pnt;
     unsigned char fst_filetype;
     unsigned subvar_jrb_count_locked : 1;
-    uint32_t stem_file_idx;
-    uint32_t stem_line_number;
-    char **stem_path_string_table;
-    struct stem_struct_t *stem_struct_base;
-    struct stem_struct_t *istem_struct_base;
-    uint32_t stem_path_string_table_siz;
-    uint32_t stem_path_string_table_alloc;
-    uint32_t stem_struct_base_siz;
-    uint32_t stem_struct_base_siz_alloc;
-    uint32_t istem_struct_base_siz;
-    uint32_t istem_struct_base_siz_alloc;
-    unsigned stem_valid : 1;
-    unsigned istem_valid : 1;
+    guint32 next_var_stem;
+    guint32 next_var_istem;
     char *fst_synclock_str;
     JRB synclock_jrb;
 #ifdef _WAVE_HAVE_JUDY


### PR DESCRIPTION
This PR moves the extracts the code that handles stems from the FST loader into a new `GwStems` class in libgtkwave.