### PR TITLE
Add GwBlackoutRegions to libgtkwave

### DIFF
--- a/lib/libgtkwave/src/gtkwave.h
+++ b/lib/libgtkwave/src/gtkwave.h
@@ -19,3 +19,4 @@
 #include "gw-stems.h"
 #include "gw-var-enums.h"
 #include "gw-tree.h"
+#include "gw-blackout-regions.h"

--- a/lib/libgtkwave/src/gw-blackout-regions.c
+++ b/lib/libgtkwave/src/gw-blackout-regions.c
@@ -1,0 +1,131 @@
+#include "gw-blackout-regions.h"
+
+typedef struct
+{
+    GwTime start;
+    GwTime end;
+} GwBlackoutRegion;
+
+struct _GwBlackoutRegions
+{
+    GObject parent_instance;
+
+    GSList *regions;
+
+    gboolean dumpoff_valid;
+    GwTime dumpoff_time;
+};
+
+G_DEFINE_TYPE(GwBlackoutRegions, gw_blackout_regions, G_TYPE_OBJECT)
+
+static void gw_blackout_regions_finalize(GObject *object)
+{
+    GwBlackoutRegions *self = GW_BLACKOUT_REGIONS(object);
+
+    g_slist_free_full(self->regions, g_free);
+
+    G_OBJECT_CLASS(gw_blackout_regions_parent_class)->finalize(object);
+}
+
+static void gw_blackout_regions_class_init(GwBlackoutRegionsClass *klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS(klass);
+
+    object_class->finalize = gw_blackout_regions_finalize;
+}
+
+static void gw_blackout_regions_init(GwBlackoutRegions *self)
+{
+    (void)self;
+}
+
+GwBlackoutRegions *gw_blackout_regions_new(void)
+{
+    return g_object_new(GW_TYPE_BLACKOUT_REGIONS, NULL);
+}
+
+void gw_blackout_regions_add(GwBlackoutRegions *self, GwTime start, GwTime end)
+{
+    g_return_if_fail(GW_IS_BLACKOUT_REGIONS(self));
+
+    GwBlackoutRegion *region = g_new0(GwBlackoutRegion, 1);
+    region->start = start;
+    region->end = end;
+
+    self->regions = g_slist_prepend(self->regions, region);
+}
+
+void gw_blackout_regions_add_dumpoff(GwBlackoutRegions *self, GwTime t)
+{
+    g_return_if_fail(GW_IS_BLACKOUT_REGIONS(self));
+
+    // Ignore repeated dumpoff commands.
+    if (self->dumpoff_valid) {
+        return;
+    }
+
+    self->dumpoff_valid = TRUE;
+    self->dumpoff_time = t;
+}
+
+void gw_blackout_regions_add_dumpon(GwBlackoutRegions *self, GwTime t)
+{
+    g_return_if_fail(GW_IS_BLACKOUT_REGIONS(self));
+
+    // Ignore dumpon commands without an associated dumpoff command.
+    if (!self->dumpoff_valid) {
+        return;
+    }
+
+    gw_blackout_regions_add(self, self->dumpoff_time, t);
+
+    self->dumpoff_valid = FALSE;
+}
+
+gboolean gw_blackout_regions_contains(GwBlackoutRegions *self, GwTime t)
+{
+    g_return_val_if_fail(GW_IS_BLACKOUT_REGIONS(self), FALSE);
+
+    for (GSList *iter = self->regions; iter != NULL; iter = iter->next) {
+        GwBlackoutRegion *region = iter->data;
+
+        if (t >= region->start && t < region->end) {
+            return TRUE;
+        }
+    }
+
+    return FALSE;
+}
+
+void gw_blackout_regions_scale(GwBlackoutRegions *self, GwTime scale)
+{
+    g_return_if_fail(GW_IS_BLACKOUT_REGIONS(self));
+
+    for (GSList *iter = self->regions; iter != NULL; iter = iter->next) {
+        GwBlackoutRegion *region = iter->data;
+
+        region->start *= scale;
+        region->end *= scale;
+    }
+}
+
+void gw_blackout_regions_foreach(GwBlackoutRegions *self,
+                                 GwBlackoutRegionsForEach function,
+                                 gpointer user_data)
+{
+    g_return_if_fail(GW_IS_BLACKOUT_REGIONS(self));
+    g_return_if_fail(function != NULL);
+
+    for (GSList *iter = self->regions; iter != NULL; iter = iter->next) {
+        GwBlackoutRegion *region = iter->data;
+
+        function(region->start, region->end, user_data);
+    }
+}
+
+guint gw_blackout_regions_length(GwBlackoutRegions *self)
+{
+    g_return_val_if_fail(GW_IS_BLACKOUT_REGIONS(self), 0);
+
+    return g_slist_length(self->regions);
+}

--- a/lib/libgtkwave/src/gw-blackout-regions.h
+++ b/lib/libgtkwave/src/gw-blackout-regions.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <glib-object.h>
+#include "gw-time.h"
+
+G_BEGIN_DECLS
+
+typedef void (*GwBlackoutRegionsForEach)(GwTime start, GwTime end, gpointer user_data);
+
+#define GW_TYPE_BLACKOUT_REGIONS (gw_blackout_regions_get_type())
+G_DECLARE_FINAL_TYPE(GwBlackoutRegions, gw_blackout_regions, GW, BLACKOUT_REGIONS, GObject)
+
+GwBlackoutRegions *gw_blackout_regions_new(void);
+
+void gw_blackout_regions_add(GwBlackoutRegions *self, GwTime start, GwTime end);
+void gw_blackout_regions_add_dumpoff(GwBlackoutRegions *self, GwTime t);
+void gw_blackout_regions_add_dumpon(GwBlackoutRegions *self, GwTime t);
+
+gboolean gw_blackout_regions_contains(GwBlackoutRegions *self, GwTime t);
+void gw_blackout_regions_scale(GwBlackoutRegions *self, GwTime scale);
+void gw_blackout_regions_foreach(GwBlackoutRegions *self,
+                                 GwBlackoutRegionsForEach function,
+                                 gpointer user_data);
+guint gw_blackout_regions_length(GwBlackoutRegions *self);
+
+G_END_DECLS

--- a/lib/libgtkwave/src/meson.build
+++ b/lib/libgtkwave/src/meson.build
@@ -1,4 +1,5 @@
 libgtkwave_public_sources = [
+    'gw-blackout-regions.c',
     'gw-color-theme.c',
     'gw-color.c',
     'gw-marker.c',
@@ -12,6 +13,7 @@ libgtkwave_public_sources = [
 libgtkwave_public_headers = [
     'gtkwave.h',
     'gw-types.h',
+    'gw-blackout-regions.h',
     'gw-bit-vector.h',
     'gw-bits.h',
     'gw-color-theme.h',

--- a/lib/libgtkwave/test/gw-blackout-regions.c
+++ b/lib/libgtkwave/test/gw-blackout-regions.c
@@ -1,0 +1,118 @@
+#include <gtkwave.h>
+
+void region_to_string(GwTime start, GwTime end, gpointer data)
+{
+    GString *output = data;
+
+    if (output->len > 0) {
+        g_string_append(output, ", ");
+    }
+
+    g_string_append_printf(output, "%" GW_TIME_FORMAT "-%" GW_TIME_FORMAT, start, end);
+}
+
+static void assert_blackout_regions(GwBlackoutRegions *blackout_regions,
+                                    const guint expected_count,
+                                    const char *expected_string)
+{
+    g_assert_cmpint(gw_blackout_regions_length(blackout_regions), ==, expected_count);
+
+    GString *string = g_string_new(NULL);
+
+    gw_blackout_regions_foreach(blackout_regions, region_to_string, string);
+
+    g_assert_cmpstr(string->str, ==, expected_string);
+
+    g_string_free(string, TRUE);
+}
+
+static void test_add(void)
+{
+    GwBlackoutRegions *regions = gw_blackout_regions_new();
+    assert_blackout_regions(regions, 0, "");
+
+    gw_blackout_regions_add(regions, 1, 2);
+    assert_blackout_regions(regions, 1, "1-2");
+
+    gw_blackout_regions_add(regions, 4, 5);
+    assert_blackout_regions(regions, 2, "4-5, 1-2");
+
+    gw_blackout_regions_add(regions, 6, 7);
+    assert_blackout_regions(regions, 3, "6-7, 4-5, 1-2");
+
+    g_object_unref(regions);
+}
+
+static void test_add_dumponoff(void)
+{
+    GwBlackoutRegions *regions = gw_blackout_regions_new();
+    assert_blackout_regions(regions, 0, "");
+
+    gw_blackout_regions_add_dumpoff(regions, 1);
+    assert_blackout_regions(regions, 0, "");
+
+    gw_blackout_regions_add_dumpon(regions, 2);
+    assert_blackout_regions(regions, 1, "1-2");
+
+    // dumpon commands without previous dumpoff should be ignored.
+    gw_blackout_regions_add_dumpon(regions, 3);
+    assert_blackout_regions(regions, 1, "1-2");
+
+    gw_blackout_regions_add_dumpoff(regions, 4);
+    assert_blackout_regions(regions, 1, "1-2");
+
+    // Repeated dumpoff commands shouldn't change the start time.
+    gw_blackout_regions_add_dumpoff(regions, 5);
+    assert_blackout_regions(regions, 1, "1-2");
+
+    gw_blackout_regions_add_dumpon(regions, 6);
+    assert_blackout_regions(regions, 2, "4-6, 1-2");
+
+    g_object_unref(regions);
+}
+
+static void test_scale(void)
+{
+    GwBlackoutRegions *regions = gw_blackout_regions_new();
+
+    gw_blackout_regions_add(regions, 1, 2);
+    gw_blackout_regions_add(regions, 3, 4);
+    gw_blackout_regions_add(regions, 10, 20);
+
+    gw_blackout_regions_scale(regions, 10);
+
+    assert_blackout_regions(regions, 3, "100-200, 30-40, 10-20");
+
+    g_object_unref(regions);
+}
+
+static void test_contains(void)
+{
+    GwBlackoutRegions *regions = gw_blackout_regions_new();
+
+    gw_blackout_regions_add(regions, 1, 2);
+    gw_blackout_regions_add(regions, 4, 6);
+
+    g_assert_false(gw_blackout_regions_contains(regions, 0));
+    g_assert_true(gw_blackout_regions_contains(regions, 1));
+    g_assert_false(gw_blackout_regions_contains(regions, 2));
+    g_assert_false(gw_blackout_regions_contains(regions, 3));
+    g_assert_true(gw_blackout_regions_contains(regions, 4));
+    g_assert_true(gw_blackout_regions_contains(regions, 5));
+    g_assert_false(gw_blackout_regions_contains(regions, 6));
+    g_assert_false(gw_blackout_regions_contains(regions, 7));
+
+    g_object_unref(regions);
+}
+
+int main(int argc, char *argv[])
+{
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/blackout_regions/add", test_add);
+    g_test_add_func("/blackout_regions/add_dumponoff", test_add_dumponoff);
+    g_test_add_func("/blackout_regions/scale", test_scale);
+    g_test_add_func("/blackout_regions/contains", test_contains);
+
+    return g_test_run();
+}

--- a/lib/libgtkwave/test/meson.build
+++ b/lib/libgtkwave/test/meson.build
@@ -1,4 +1,5 @@
 libgtkwave_tests = [
+    'gw-blackout-regions',
     'gw-color-theme',
     'gw-color',
     'gw-marker',

--- a/src/currenttime.h
+++ b/src/currenttime.h
@@ -24,12 +24,6 @@
 #define WAVE_INF_SCALING (0.5)
 #define WAVE_SI_UNITS " munpfaz"
 
-struct blackout_region_t
-{
-    struct blackout_region_t *next;
-    GwTime bstart, bend;
-};
-
 /* currenttime.c protos */
 
 void fractional_timescale_fix(char *);

--- a/src/globals.c
+++ b/src/globals.c
@@ -805,7 +805,6 @@ static const struct Global globals_base_values = {
     0, /* vcdbyteno_vcd_partial_c_2 516 */
     0, /* error_count_vcd_partial_c_2 517 */
     0, /* header_over_vcd_partial_c_2 518 */
-    0, /* dumping_off_vcd_partial_c_2 519 */
     -1, /* start_time_vcd_partial_c_2 520 */
     -1, /* end_time_vcd_partial_c_2 521 */
     -1, /* current_time_vcd_partial_c_2 522 */

--- a/src/globals.h
+++ b/src/globals.h
@@ -784,7 +784,6 @@ struct Global
     off_t vcdbyteno_vcd_partial_c_2; /* from vcd_partial.c 555 */
     int error_count_vcd_partial_c_2; /* from vcd_partial.c 556 */
     int header_over_vcd_partial_c_2; /* from vcd_partial.c 557 */
-    int dumping_off_vcd_partial_c_2; /* from vcd_partial.c 558 */
     GwTime start_time_vcd_partial_c_2; /* from vcd_partial.c 559 */
     GwTime end_time_vcd_partial_c_2; /* from vcd_partial.c 560 */
     GwTime current_time_vcd_partial_c_2; /* from vcd_partial.c 561 */
@@ -907,7 +906,7 @@ struct Global
     char zoom_dyne; /* from menu.c */
     int cursor_snap; /* from wavewindow.c 659 */
     float old_wvalue; /* from wavewindow.c 660 */
-    struct blackout_region_t *blackout_regions; /* from wavewindow.c 661 */
+    GwBlackoutRegions *blackout_regions; /* from wavewindow.c 661 */
     GwTime zoom; /* from wavewindow.c 662 */
     GwTime scale; /* from wavewindow.c 663 */
     GwTime nsperframe; /* from wavewindow.c 664 */

--- a/src/gw-time-display.c
+++ b/src/gw-time-display.c
@@ -119,17 +119,6 @@ static gchar *reformat_time_as_frequency(GwTime val, char dim)
     }
 }
 
-static gboolean is_in_blackout_region(GwTime val)
-{
-    for (struct blackout_region_t *bt = GLOBALS->blackout_regions; bt != NULL; bt = bt->next) {
-        if (val >= bt->bstart && val < bt->bend) {
-            return TRUE;
-        }
-    }
-
-    return FALSE;
-}
-
 struct _GwTimeDisplay
 {
     GtkBox parent_instance;
@@ -225,7 +214,8 @@ static void gw_time_display_update(GwTimeDisplay *self)
 
         gchar *text = reformat_time_2(cursor_pos, GLOBALS->time_dimension, FALSE);
 
-        if (is_in_blackout_region(cursor_pos)) {
+        if (GLOBALS->blackout_regions != NULL &&
+            gw_blackout_regions_contains(GLOBALS->blackout_regions, cursor_pos)) {
             gchar *last_space = g_strrstr(text, " ");
             if (last_space != NULL) {
                 *last_space = '*';

--- a/src/vcd_recoder.c
+++ b/src/vcd_recoder.c
@@ -1864,25 +1864,11 @@ static void vcd_parse(void)
                 break; /* just loop through..                 */
             case T_DUMPOFF:
             case T_DUMPPORTSOFF:
-                GLOBALS->dumping_off_vcd_recoder_c_3 = 1;
-                /* if((!GLOBALS->blackout_regions)||((GLOBALS->blackout_regions)&&(GLOBALS->blackout_regions->bstart<=GLOBALS->blackout_regions->bend)))
-                 * : remove redundant condition */
-                if ((!GLOBALS->blackout_regions) ||
-                    (GLOBALS->blackout_regions->bstart <= GLOBALS->blackout_regions->bend)) {
-                    struct blackout_region_t *bt = calloc_2(1, sizeof(struct blackout_region_t));
-
-                    bt->bstart = GLOBALS->current_time_vcd_recoder_c_3;
-                    bt->next = GLOBALS->blackout_regions;
-                    GLOBALS->blackout_regions = bt;
-                }
+                gw_blackout_regions_add_dumpoff(GLOBALS->blackout_regions, GLOBALS->current_time_vcd_recoder_c_3);
                 break;
             case T_DUMPON:
             case T_DUMPPORTSON:
-                GLOBALS->dumping_off_vcd_recoder_c_3 = 0;
-                if ((GLOBALS->blackout_regions) &&
-                    (GLOBALS->blackout_regions->bstart > GLOBALS->blackout_regions->bend)) {
-                    GLOBALS->blackout_regions->bend = GLOBALS->current_time_vcd_recoder_c_3;
-                }
+                gw_blackout_regions_add_dumpon(GLOBALS->blackout_regions, GLOBALS->current_time_vcd_recoder_c_3);
                 break;
             case T_DUMPVARS:
             case T_DUMPPORTS:
@@ -1900,10 +1886,7 @@ static void vcd_parse(void)
                 sync_end(NULL); /* skip over unknown keywords */
                 break;
             case T_EOF:
-                if ((GLOBALS->blackout_regions) &&
-                    (GLOBALS->blackout_regions->bstart > GLOBALS->blackout_regions->bend)) {
-                    GLOBALS->blackout_regions->bend = GLOBALS->current_time_vcd_recoder_c_3;
-                }
+                gw_blackout_regions_add_dumpon(GLOBALS->blackout_regions, GLOBALS->current_time_vcd_recoder_c_3);
 
                 GLOBALS->pv_vcd_recoder_c_3 = NULL;
                 if (GLOBALS->prev_hier_uncompressed_name) {
@@ -2610,14 +2593,7 @@ GwTime vcd_recoder_main(char *fname)
 
     getch_free(); /* free membuff for vcd getch buffer */
 
-    if (GLOBALS->blackout_regions) {
-        struct blackout_region_t *bt = GLOBALS->blackout_regions;
-        while (bt) {
-            bt->bstart *= GLOBALS->time_scale;
-            bt->bend *= GLOBALS->time_scale;
-            bt = bt->next;
-        }
-    }
+    gw_blackout_regions_scale(GLOBALS->blackout_regions, GLOBALS->time_scale);
 
     /* is_vcd=~0; */
     GLOBALS->is_lx2 = LXT2_IS_VLIST;


### PR DESCRIPTION
This PR adds a new GwBlackoutRegions object to manage blackout regions in FST and VCD files.