### PR TITLE
Use structs for dump file loader state

### DIFF
--- a/src/fst.h
+++ b/src/fst.h
@@ -19,9 +19,14 @@
 #include "vcd.h"
 #include "tree_component.h"
 
+typedef struct _FstFile FstFile;
+
 GwTime fst_main(char *fname, char *skip_start, char *skip_end);
-void import_fst_trace(GwNode *np);
-void fst_set_fac_process_mask(GwNode *np);
-void fst_import_masked(void);
+void import_fst_trace(FstFile *self, GwNode *np);
+void fst_set_fac_process_mask(FstFile *self, GwNode *np);
+void fst_import_masked(FstFile *self);
+
+void fst_file_close(FstFile *self);
+gchar *fst_file_get_subvar(FstFile *self, gint index);
 
 #endif

--- a/src/globals.c
+++ b/src/globals.c
@@ -720,11 +720,7 @@ static const struct Global globals_base_values = {
     0, /* vcd_preserve_glitches 478 */
     0, /* vcd_preserve_glitches_real */
     NULL, /* vcd_save_handle 479 */
-    NULL, /* vcd_handle_vcd_c_1 480 */
     0, /* vcd_is_compressed_vcd_c_1 481 */
-    0, /* vcdbyteno_vcd_c_1 482 */
-    0, /* error_count_vcd_c_1 483 */
-    0, /* header_over_vcd_c_1 484 */
     0, /* dumping_off_vcd_c_1 485 */
     -1, /* start_time_vcd_c_1 486 */
     -1, /* end_time_vcd_c_1 487 */
@@ -797,46 +793,13 @@ static const struct Global globals_base_values = {
     NULL, /* vsplitcurr */
     0, /* var_prevch_vcd_partial_c_2 544 */
     0, /* timeset_vcd_partial_c_1 547 */
+    0, /* vcd_hash_max_partial */
+    0, /* vcd_hash_kill_partial */
 
     /*
      * vcd_recoder.c
      */
-    NULL, /* time_vlist_vcd_recoder_c_1 548 */
-    0, /* time_vlist_count_vcd_recoder_c_1 549 */
-    NULL, /* vcd_handle_vcd_recoder_c_2 550 */
-    0, /* vcd_is_compressed_vcd_recoder_c_2 551 */
-    0, /* vcdbyteno_vcd_recoder_c_3 552 */
-    0, /* error_count_vcd_recoder_c_3 553 */
-    0, /* header_over_vcd_recoder_c_3 554 */
-    0, /* dumping_off_vcd_recoder_c_3 555 */
-    -1, /* start_time_vcd_recoder_c_3 556 */
-    -1, /* end_time_vcd_recoder_c_3 557 */
-    -1, /* current_time_vcd_recoder_c_3 558 */
-    0, /* num_glitches_vcd_recoder_c_4 559 */
-    0, /* num_glitch_regions_vcd_recoder_c_4 560 */
-    NULL, /* pv_vcd_recoder_c_3 561 */
-    NULL, /* rootv */
-    NULL, /* vcdbuf_vcd_recoder_c_3 562 */
-    NULL, /* vst */
-    NULL, /* vend */
-    1024, /* T_MAX_STR_vcd_recoder_c_3 564 */
-    NULL, /* yytext_vcd_recoder_c_3 565 */
-    0, /* yylen_vcd_recoder_c_3 566 */
-    0, /* yylen_cache */
-    NULL, /* vcdsymroot_vcd_recoder_c_3 567 */
-    NULL, /* vcdsymcurr */
-    NULL, /* sorted_vcd_recoder_c_3 568 */
-    NULL, /* indexed_vcd_recoder_c_3 569 */
-    0, /* numsyms_vcd_recoder_c_3 570 */
-    ~0, /* vcd_minid_vcd_recoder_c_3 571 */
-    0, /* vcd_maxid_vcd_recoder_c_3 572 */
-    0, /* err_vcd_recoder_c_3 573 */
-    0, /* vcd_fsiz_vcd_recoder_c_2 574 */
-    NULL, /* varsplit_vcd_recoder_c_3 575 */
-    NULL, /* vsplitcurr */
-    0, /* var_prevch_vcd_recoder_c_3 576 */
-    0, /* vcd_hash_max */
-    0, /* vcd_hash_kill */
+    NULL, /* vcd_file */
 
     /*
      * vcd_saver.c
@@ -1084,24 +1047,6 @@ static int handle_setjmp(void)
     } else {
         free(GLOBALS->vcd_jmp_buf);
         GLOBALS->vcd_jmp_buf = NULL;
-        if (GLOBALS->vcd_handle_vcd_c_1) {
-            if (GLOBALS->vcd_is_compressed_vcd_c_1) {
-                pclose(GLOBALS->vcd_handle_vcd_c_1);
-                GLOBALS->vcd_handle_vcd_c_1 = NULL;
-            } else {
-                fclose(GLOBALS->vcd_handle_vcd_c_1);
-                GLOBALS->vcd_handle_vcd_c_1 = NULL;
-            }
-        }
-        if (GLOBALS->vcd_handle_vcd_recoder_c_2) {
-            if (GLOBALS->vcd_is_compressed_vcd_recoder_c_2) {
-                pclose(GLOBALS->vcd_handle_vcd_recoder_c_2);
-                GLOBALS->vcd_handle_vcd_recoder_c_2 = NULL;
-            } else {
-                fclose(GLOBALS->vcd_handle_vcd_recoder_c_2);
-                GLOBALS->vcd_handle_vcd_recoder_c_2 = NULL;
-            }
-        }
 
         free_outstanding(); /* free anything allocated in loader ctx */
 

--- a/src/globals.c
+++ b/src/globals.c
@@ -215,35 +215,12 @@ static const struct Global globals_base_values = {
      * fst.c
      */
     NULL, /* fst_fst_c_1 */
-    NULL, /* fst_scope_name */
-    0, /* fst_scope_name_len */
-    0, /* first_cycle_fst_c_3 */
-    0, /* last_cycle_fst_c_3 */
-    0, /* total_cycles_fst_c_3 */
-    NULL, /* fst_table_fst_c_1 */
-    NULL, /* mvlfacs_fst_c_3 */
-    NULL, /* mvlfacs_fst_alias */
-    NULL, /* mvlfacs_fst_rvs_alias */
-    0, /* fst_maxhandle */
-    0, /* busycnt_fst_c_2 */
-    NULL, /* double_curr_fst */
-    NULL, /* double_fini_fst */
     0, /* nonimplicit_direction_encountered */
     0, /* supplemental_datatypes_encountered */
     0, /* supplemental_vartypes_encountered */
     0, /* is_vhdl_component_format */
-    NULL, /* subvar_jrb */
-    0, /* subvar_jrb_count */
-    NULL, /* subvar_pnt */
-    0, /* fst_filetype */
-    0, /* subvar_jrb_count_locked */
-    0, /* next_var_stem */
-    0, /* next_var_istem */
-    NULL, /* fst_synclock_str */
-    NULL, /* synclock_jrb */
     NULL, /* xl_enum_filter */
     0, /* num_xl_enum_filter */
-    0, /* queued_xl_enum_filter */
     NULL, /* enum_nptrs_jrb */
 
     /*
@@ -1603,18 +1580,6 @@ void reload_into_new_context_2(void)
                                  &GLOBALS->unoptimized_vcd_file_name);
     }
 
-    /* fst.c, though might be others later */
-    if (GLOBALS->subvar_jrb) {
-        jrb_free_tree(GLOBALS->subvar_jrb);
-        GLOBALS->subvar_jrb = NULL;
-        GLOBALS->subvar_jrb_count = 0;
-    }
-
-    if (GLOBALS->synclock_jrb) {
-        jrb_free_tree(GLOBALS->synclock_jrb);
-        GLOBALS->synclock_jrb = NULL;
-    }
-
     if (GLOBALS->enum_nptrs_jrb) {
         jrb_free_tree(GLOBALS->enum_nptrs_jrb);
         GLOBALS->enum_nptrs_jrb = NULL;
@@ -1634,8 +1599,7 @@ void reload_into_new_context_2(void)
     /* deallocate any loader-related stuff */
     switch (GLOBALS->loaded_file_type) {
         case FST_FILE:
-            fstReaderClose(GLOBALS->fst_fst_c_1);
-            GLOBALS->fst_fst_c_1 = NULL;
+            g_clear_pointer(&GLOBALS->fst_file, fst_file_close);
             break;
 
 #ifdef EXTLOAD_SUFFIX
@@ -1795,7 +1759,7 @@ void reload_into_new_context_2(void)
 
             case FST_FILE:
                 fst_main(GLOBALS->loaded_file_name, GLOBALS->skip_start, GLOBALS->skip_end);
-                load_was_success = (GLOBALS->fst_fst_c_1 != NULL);
+                load_was_success = (GLOBALS->fst_file != NULL);
                 break;
 
             case GHW_FILE:
@@ -2083,8 +2047,7 @@ void free_and_destroy_page_context(void)
     /* deallocate any loader-related stuff */
     switch (GLOBALS->loaded_file_type) {
         case FST_FILE:
-            fstReaderClose(GLOBALS->fst_fst_c_1);
-            GLOBALS->fst_fst_c_1 = NULL;
+            g_clear_pointer(&GLOBALS->fst_file, fst_file_close);
             break;
 
 #ifdef EXTLOAD_SUFFIX

--- a/src/globals.c
+++ b/src/globals.c
@@ -720,43 +720,14 @@ static const struct Global globals_base_values = {
     0, /* vcd_preserve_glitches 478 */
     0, /* vcd_preserve_glitches_real */
     NULL, /* vcd_save_handle 479 */
-    0, /* vcd_is_compressed_vcd_c_1 481 */
-    0, /* dumping_off_vcd_c_1 485 */
-    -1, /* start_time_vcd_c_1 486 */
-    -1, /* end_time_vcd_c_1 487 */
-    -1, /* current_time_vcd_c_1 488 */
-    0, /* num_glitches_vcd_c_2 489 */
-    0, /* num_glitch_regions_vcd_c_2 490 */
     {0, 0}, /* vcd_hier_delimeter 491 */
-    NULL, /* pv_vcd_c_1 492 */
-    NULL, /* rootv_vcd_c_1 */
-    NULL, /* vcdbuf_vcd_c_1 493 */
-    NULL, /* vst */
-    NULL, /* vend */
     0, /* escaped_names_found_vcd_c_1 494 */
     NULL, /* slistroot 495 */
     NULL, /* slistcurr */
     NULL, /* slisthier 496 */
     0, /* slisthier_len 497x */
-    1024, /* T_MAX_STR_vcd_c_1 499 */
-    NULL, /* yytext_vcd_c_1 500 */
-    0, /* yylen_vcd_c_1 501 */
-    0, /* yylen_cache */
-    NULL, /* vcdsymroot_vcd_c_1 502 */
-    NULL, /* vcdsymcurr */
-    NULL, /* sorted_vcd_c_1 503 */
-    NULL, /* indexed_vcd_c_1 504 */
-    0, /* numsyms_vcd_c_1 505 */
     NULL, /* he_curr_vcd_c_1 506 */
     NULL, /* he_fini */
-    ~0, /* vcd_minid_vcd_c_1 508 */
-    0, /* vcd_maxid_vcd_c_1 509 */
-    0, /* err_vcd_c_1 510 */
-    0, /* vcd_fsiz_vcd_c_1 511 */
-    NULL, /* varsplit_vcd_c_1 512 */
-    NULL, /* varsplitcurr */
-    0, /* var_prevch_vcd_c_1 513 */
-    0, /* vcd_already_backtracked */
 
     /*
      * vcd_partial.c

--- a/src/globals.c
+++ b/src/globals.c
@@ -854,17 +854,6 @@ static const struct Global globals_base_values = {
     4, /* vlist_compression_depth 583 */
 
     /*
-     * vzt.c
-     */
-    NULL, /* vzt_vzt_c_1 584 */
-    0, /* first_cycle_vzt_c_3 585 */
-    0, /* last_cycle */
-    0, /* total_cycles */
-    NULL, /* vzt_table_vzt_c_1 586 */
-    NULL, /* mvlfacs_vzt_c_3 587 */
-    0, /* busycnt_vzt_c_2 588 */
-
-    /*
      * wavewindow.c
      */
     0, /* highlight_wavewindow */

--- a/src/globals.c
+++ b/src/globals.c
@@ -226,21 +226,7 @@ static const struct Global globals_base_values = {
     /*
      * ghw.c
      */
-    0, /* nxp_ghw_c_1 93 */
-    0, /* sym_which_ghw_c_1 95 */
-    NULL, /* gwt_ghw_c_1 96 */
-    NULL, /* gwt_corr_ghw_c_1 97 */
-    1, /* xlat_1164_ghw_c_1 98 */
     0, /* is_ghw 99 */
-    NULL, /* asbuf */
-    0, /* nbr_sig_ref_ghw_c_1 101 */
-    0, /* num_glitches_ghw_c_1 102 */
-    0, /*  num_glitch_regions_ghw_c_1 */
-    0, /* fac_name_ghw_c_1 104 */
-    0, /* fac_name_len_ghw_c_1 105 */
-    0, /* fac_name_max_ghw_c_1 106 */
-    0, /* last_fac_ghw_c_1 107 */
-    0, /* warned_ghw_c_1 108 */
 
     /*
      * globals.c

--- a/src/globals.h
+++ b/src/globals.h
@@ -239,21 +239,7 @@ struct Global
     /*
      * ghw.c
      */
-    GwNode **nxp_ghw_c_1; /* from ghw.c 95 */
-    int sym_which_ghw_c_1; /* from ghw.c 98 */
-    struct ghw_tree_node *gwt_ghw_c_1; /* from ghw.c 99 */
-    struct ghw_tree_node *gwt_corr_ghw_c_1; /* from ghw.c 100 */
-    int xlat_1164_ghw_c_1; /* from ghw.c 101 */
     char is_ghw; /* from ghw.c 102 */
-    char *asbuf; /* from ghw.c 103 */
-    int nbr_sig_ref_ghw_c_1; /* from ghw.c 104 */
-    int num_glitches_ghw_c_1; /* from ghw.c 105 */
-    int num_glitch_regions_ghw_c_1; /* from ghw.c 106 */
-    char *fac_name_ghw_c_1; /* from ghw.c 108 */
-    int fac_name_len_ghw_c_1; /* from ghw.c 109 */
-    int fac_name_max_ghw_c_1; /* from ghw.c 110 */
-    int last_fac_ghw_c_1; /* from ghw.c 111 */
-    int warned_ghw_c_1; /* from ghw.c 112 */
 
     /*
      * globals.c

--- a/src/globals.h
+++ b/src/globals.h
@@ -700,43 +700,14 @@ struct Global
     char vcd_preserve_glitches; /* from vcd.c 509 */
     char vcd_preserve_glitches_real;
     FILE *vcd_save_handle; /* from vcd.c 510 */
-    char vcd_is_compressed_vcd_c_1; /* from vcd.c 512 */
-    int dumping_off_vcd_c_1; /* from vcd.c 516 */
-    GwTime start_time_vcd_c_1; /* from vcd.c 517 */
-    GwTime end_time_vcd_c_1; /* from vcd.c 518 */
-    GwTime current_time_vcd_c_1; /* from vcd.c 519 */
-    int num_glitches_vcd_c_2; /* from vcd.c 520 */
-    int num_glitch_regions_vcd_c_2; /* from vcd.c 521 */
     char vcd_hier_delimeter[2]; /* from vcd.c 522 */
-    struct vcdsymbol *pv_vcd_c_1; /* from vcd.c 523 */
-    struct vcdsymbol *rootv_vcd_c_1; /* from vcd.c 524 */
-    char *vcdbuf_vcd_c_1; /* from vcd.c 525 */
-    char *vst_vcd_c_1; /* from vcd.c 526 */
-    char *vend_vcd_c_1; /* from vcd.c 527 */
     int escaped_names_found_vcd_c_1; /* from vcd.c 528 */
     struct slist *slistroot; /* from vcd.c 529 */
     struct slist *slistcurr; /* from vcd.c 530 */
     char *slisthier; /* from vcd.c 531 */
     int slisthier_len; /* from vcd.c 532 */
-    int T_MAX_STR_vcd_c_1; /* from vcd.c 534 */
-    char *yytext_vcd_c_1; /* from vcd.c 535 */
-    int yylen_vcd_c_1; /* from vcd.c 536 */
-    int yylen_cache_vcd_c_1; /* from vcd.c 537 */
-    struct vcdsymbol *vcdsymroot_vcd_c_1; /* from vcd.c 538 */
-    struct vcdsymbol *vcdsymcurr_vcd_c_1; /* from vcd.c 539 */
-    struct vcdsymbol **sorted_vcd_c_1; /* from vcd.c 540 */
-    struct vcdsymbol **indexed_vcd_c_1; /* from vcd.c 541 */
-    int numsyms_vcd_c_1; /* from vcd.c 542 */
     GwHistEnt *he_curr_vcd_c_1; /* from vcd.c 543 */
     GwHistEnt *he_fini_vcd_c_1; /* from vcd.c 544 */
-    unsigned int vcd_minid_vcd_c_1; /* from vcd.c 546 */
-    unsigned int vcd_maxid_vcd_c_1; /* from vcd.c 547 */
-    int err_vcd_c_1; /* from vcd.c 548 */
-    off_t vcd_fsiz_vcd_c_1; /* from vcd.c 549 */
-    char *varsplit_vcd_c_1; /* from vcd.c 550 */
-    char *vsplitcurr_vcd_c_1; /* from vcd.c 551 */
-    int var_prevch_vcd_c_1; /* from vcd.c 552 */
-    char vcd_already_backtracked;
 
     /*
      * vcd_partial.c

--- a/src/globals.h
+++ b/src/globals.h
@@ -700,11 +700,7 @@ struct Global
     char vcd_preserve_glitches; /* from vcd.c 509 */
     char vcd_preserve_glitches_real;
     FILE *vcd_save_handle; /* from vcd.c 510 */
-    FILE *vcd_handle_vcd_c_1; /* from vcd.c 511 */
     char vcd_is_compressed_vcd_c_1; /* from vcd.c 512 */
-    off_t vcdbyteno_vcd_c_1; /* from vcd.c 513 */
-    int error_count_vcd_c_1; /* from vcd.c 514 */
-    int header_over_vcd_c_1; /* from vcd.c 515 */
     int dumping_off_vcd_c_1; /* from vcd.c 516 */
     GwTime start_time_vcd_c_1; /* from vcd.c 517 */
     GwTime end_time_vcd_c_1; /* from vcd.c 518 */
@@ -777,46 +773,13 @@ struct Global
     char *vsplitcurr_vcd_partial_c_2; /* from vcd_partial.c 588 */
     int var_prevch_vcd_partial_c_2; /* from vcd_partial.c 589 */
     int timeset_vcd_partial_c_1; /* from vcd_partial.c 592 */
+    unsigned int vcd_hash_max_partial; 
+    int vcd_hash_kill_partial;
 
     /*
      * vcd_recoder.c
      */
-    struct vlist_t *time_vlist_vcd_recoder_c_1; /* from vcd_recoder.c 593 */
-    unsigned int time_vlist_count_vcd_recoder_c_1; /* from vcd_recoder.c 594 */
-    FILE *vcd_handle_vcd_recoder_c_2; /* from vcd_recoder.c 595 */
-    char vcd_is_compressed_vcd_recoder_c_2; /* from vcd_recoder.c 596 */
-    off_t vcdbyteno_vcd_recoder_c_3; /* from vcd_recoder.c 597 */
-    int error_count_vcd_recoder_c_3; /* from vcd_recoder.c 598 */
-    int header_over_vcd_recoder_c_3; /* from vcd_recoder.c 599 */
-    int dumping_off_vcd_recoder_c_3; /* from vcd_recoder.c 600 */
-    GwTime start_time_vcd_recoder_c_3; /* from vcd_recoder.c 601 */
-    GwTime end_time_vcd_recoder_c_3; /* from vcd_recoder.c 602 */
-    GwTime current_time_vcd_recoder_c_3; /* from vcd_recoder.c 603 */
-    int num_glitches_vcd_recoder_c_4; /* from vcd_recoder.c 604 */
-    int num_glitch_regions_vcd_recoder_c_4; /* from vcd_recoder.c 605 */
-    struct vcdsymbol *pv_vcd_recoder_c_3; /* from vcd_recoder.c 606 */
-    struct vcdsymbol *rootv_vcd_recoder_c_3; /* from vcd_recoder.c 607 */
-    char *vcdbuf_vcd_recoder_c_3; /* from vcd_recoder.c 608 */
-    char *vst_vcd_recoder_c_3; /* from vcd_recoder.c 609 */
-    char *vend_vcd_recoder_c_3; /* from vcd_recoder.c 610 */
-    int T_MAX_STR_vcd_recoder_c_3; /* from vcd_recoder.c 612 */
-    char *yytext_vcd_recoder_c_3; /* from vcd_recoder.c 613 */
-    int yylen_vcd_recoder_c_3; /* from vcd_recoder.c 614 */
-    int yylen_cache_vcd_recoder_c_3; /* from vcd_recoder.c 615 */
-    struct vcdsymbol *vcdsymroot_vcd_recoder_c_3; /* from vcd_recoder.c 616 */
-    struct vcdsymbol *vcdsymcurr_vcd_recoder_c_3; /* from vcd_recoder.c 617 */
-    struct vcdsymbol **sorted_vcd_recoder_c_3; /* from vcd_recoder.c 618 */
-    struct vcdsymbol **indexed_vcd_recoder_c_3; /* from vcd_recoder.c 619 */
-    int numsyms_vcd_recoder_c_3; /* from vcd_recoder.c 620 */
-    unsigned int vcd_minid_vcd_recoder_c_3; /* from vcd_recoder.c 621 */
-    unsigned int vcd_maxid_vcd_recoder_c_3; /* from vcd_recoder.c 622 */
-    int err_vcd_recoder_c_3; /* from vcd_recoder.c 623 */
-    off_t vcd_fsiz_vcd_recoder_c_2; /* from vcd_recoder.c 624 */
-    char *varsplit_vcd_recoder_c_3; /* from vcd_recoder.c 625 */
-    char *vsplitcurr_vcd_recoder_c_3; /* from vcd_recoder.c 626 */
-    int var_prevch_vcd_recoder_c_3; /* from vcd_recoder.c 627 */
-    unsigned int vcd_hash_max; /* from vcd_recoder.c */
-    int vcd_hash_kill; /* from vcd_recoder.c */
+    VcdFile *vcd_file;
 
     /*
      * vcd_saver.c

--- a/src/globals.h
+++ b/src/globals.h
@@ -834,17 +834,6 @@ struct Global
     int vlist_compression_depth; /* from vlist.c 634 */
 
     /*
-     * vzt.c
-     */
-    struct vzt_rd_trace *vzt_vzt_c_1; /* from vzt.c 635 */
-    GwTime first_cycle_vzt_c_3; /* from vzt.c 636 */
-    GwTime last_cycle_vzt_c_3; /* from vzt.c 637 */
-    GwTime total_cycles_vzt_c_3; /* from vzt.c 638 */
-    struct lx2_entry *vzt_table_vzt_c_1; /* from vzt.c 639 */
-    GwFac *mvlfacs_vzt_c_3; /* from vzt.c 640 */
-    int busycnt_vzt_c_2; /* from vzt.c 641 */
-
-    /*
      * wavewindow.c
      */
     char highlight_wavewindow; /* from wavewindow.c */

--- a/src/globals.h
+++ b/src/globals.h
@@ -58,6 +58,7 @@
 #include "vlist.h"
 #include "version.h"
 #include "extload.h"
+#include "fst.h"
 
 #ifdef _WAVE_HAVE_JUDY
 #include <Judy.h>
@@ -222,40 +223,17 @@ struct Global
     /*
      * fst.c
      */
-    void *fst_fst_c_1;
-    const char *fst_scope_name;
-    int fst_scope_name_len;
-    GwTime first_cycle_fst_c_3;
-    GwTime last_cycle_fst_c_3;
-    GwTime total_cycles_fst_c_3;
-    struct lx2_entry *fst_table_fst_c_1;
-    GwFac *mvlfacs_fst_c_3;
-    fstHandle *mvlfacs_fst_alias;
-    fstHandle *mvlfacs_fst_rvs_alias;
-    fstHandle fst_maxhandle;
-    int busycnt_fst_c_2;
-    double *double_curr_fst;
-    double *double_fini_fst;
+    FstFile *fst_file;
     char nonimplicit_direction_encountered;
     char supplemental_datatypes_encountered;
     char supplemental_vartypes_encountered;
     char is_vhdl_component_format;
-    JRB subvar_jrb;
-    unsigned int subvar_jrb_count;
-    char **subvar_pnt;
-    unsigned char fst_filetype;
-    unsigned subvar_jrb_count_locked : 1;
-    guint32 next_var_stem;
-    guint32 next_var_istem;
-    char *fst_synclock_str;
-    JRB synclock_jrb;
 #ifdef _WAVE_HAVE_JUDY
     Pvoid_t *xl_enum_filter;
 #else
     struct xl_tree_node **xl_enum_filter;
 #endif
     int num_xl_enum_filter;
-    fstEnumHandle queued_xl_enum_filter;
     JRB enum_nptrs_jrb;
 
     /*

--- a/src/lx2.c
+++ b/src/lx2.c
@@ -31,7 +31,7 @@ void import_lx2_trace(GwNode *np)
 {
     switch (GLOBALS->is_lx2) {
         case LXT2_IS_VLIST:
-            import_vcd_trace(np);
+            import_vcd_trace(GLOBALS->vcd_file, np);
             return;
         case LXT2_IS_FST:
             import_fst_trace(GLOBALS->fst_file, np);
@@ -52,7 +52,7 @@ void lx2_set_fac_process_mask(GwNode *np)
 {
     switch (GLOBALS->is_lx2) {
         case LXT2_IS_VLIST:
-            vcd_set_fac_process_mask(np);
+            vcd_set_fac_process_mask(GLOBALS->vcd_file, np);
             return;
         case LXT2_IS_FST:
             fst_set_fac_process_mask(GLOBALS->fst_file, np);
@@ -70,7 +70,7 @@ void lx2_import_masked(void)
 {
     switch (GLOBALS->is_lx2) {
         case LXT2_IS_VLIST:
-            vcd_import_masked();
+            vcd_import_masked(GLOBALS->vcd_file);
             return;
         case LXT2_IS_FST:
             fst_import_masked(GLOBALS->fst_file);

--- a/src/lx2.c
+++ b/src/lx2.c
@@ -34,7 +34,7 @@ void import_lx2_trace(GwNode *np)
             import_vcd_trace(np);
             return;
         case LXT2_IS_FST:
-            import_fst_trace(np);
+            import_fst_trace(GLOBALS->fst_file, np);
             return;
         case LXT2_IS_FSDB:
             import_extload_trace(np);
@@ -55,7 +55,7 @@ void lx2_set_fac_process_mask(GwNode *np)
             vcd_set_fac_process_mask(np);
             return;
         case LXT2_IS_FST:
-            fst_set_fac_process_mask(np);
+            fst_set_fac_process_mask(GLOBALS->fst_file, np);
             return;
         case LXT2_IS_FSDB:
             fsdb_set_fac_process_mask(np);
@@ -73,7 +73,7 @@ void lx2_import_masked(void)
             vcd_import_masked();
             return;
         case LXT2_IS_FST:
-            fst_import_masked();
+            fst_import_masked(GLOBALS->fst_file);
             return;
         case LXT2_IS_FSDB:
             fsdb_import_masked();

--- a/src/main.c
+++ b/src/main.c
@@ -1715,7 +1715,7 @@ loader_check_head:
 
                 switch (GLOBALS->is_lx2) {
                     case LXT2_IS_VLIST:
-                        vcd_import_masked();
+                        vcd_import_masked(GLOBALS->vcd_file);
                         break;
                     case LXT2_IS_FST:
                         fst_import_masked(GLOBALS->fst_file);

--- a/src/main.c
+++ b/src/main.c
@@ -1549,7 +1549,7 @@ loader_check_head:
         strcpy(GLOBALS->aet_name, GLOBALS->loaded_file_name);
         GLOBALS->loaded_file_type = FST_FILE;
         fst_main(GLOBALS->loaded_file_name, GLOBALS->skip_start, GLOBALS->skip_end);
-        if (!GLOBALS->fst_fst_c_1) {
+        if (GLOBALS->fst_file == NULL) {
             fprintf(stderr,
                     "GTKWAVE | Could not initialize '%s'%s.\n",
                     GLOBALS->loaded_file_name,
@@ -1718,7 +1718,7 @@ loader_check_head:
                         vcd_import_masked();
                         break;
                     case LXT2_IS_FST:
-                        fst_import_masked();
+                        fst_import_masked(GLOBALS->fst_file);
                         break;
                     case LXT2_IS_FSDB:
                         fsdb_import_masked();

--- a/src/menu.c
+++ b/src/menu.c
@@ -2727,14 +2727,6 @@ int menu_new_viewer_tab_cleanup_2(char *fname, int optimize_vcd)
 
         rc = 1;
     } else {
-        if (GLOBALS->vcd_handle_vcd_c_1) {
-            fclose(GLOBALS->vcd_handle_vcd_c_1);
-            GLOBALS->vcd_handle_vcd_c_1 = NULL;
-        }
-        if (GLOBALS->vcd_handle_vcd_recoder_c_2) {
-            fclose(GLOBALS->vcd_handle_vcd_recoder_c_2);
-            GLOBALS->vcd_handle_vcd_recoder_c_2 = NULL;
-        }
         free_outstanding(); /* free anything allocated in loader ctx */
         free(GLOBALS);
         GLOBALS = NULL; /* valgrind fix */

--- a/src/tcl_commands.c
+++ b/src/tcl_commands.c
@@ -321,7 +321,7 @@ static int gtkwavetcl_getFacVtype(ClientData clientData,
             int vardt;
 
             varxt = GLOBALS->facs[which]->n->varxt;
-            varxt_pnt = varxt ? varxt_fix(GLOBALS->subvar_pnt[varxt]) : NULL;
+            varxt_pnt = varxt ? varxt_fix(fst_file_get_subvar(GLOBALS->fst_file, varxt)) : NULL;
 
             vartype = GLOBALS->facs[which]->n->vartype;
             if ((vartype < 0) || (vartype > GW_VAR_TYPE_MAX)) {
@@ -364,7 +364,7 @@ static int gtkwavetcl_getFacDtype(ClientData clientData,
             int vardt;
 
             varxt = GLOBALS->facs[which]->n->varxt;
-            varxt_pnt = varxt ? varxt_fix(GLOBALS->subvar_pnt[varxt]) : NULL;
+            varxt_pnt = varxt ? varxt_fix(fst_file_get_subvar(GLOBALS->fst_file, varxt)) : NULL;
 
             vardt = GLOBALS->facs[which]->n->vardt;
             if ((vardt < 0) || (vardt > GW_VAR_DATA_TYPE_MAX)) {

--- a/src/treesearch.c
+++ b/src/treesearch.c
@@ -159,7 +159,7 @@ void fill_sig_store(void)
         t_prev = t;
 
         varxt = GLOBALS->facs[i]->n->varxt;
-        varxt_pnt = varxt ? varxt_fix(GLOBALS->subvar_pnt[varxt]) : NULL;
+        varxt_pnt = varxt ? varxt_fix(fst_file_get_subvar(GLOBALS->fst_file, varxt)) : NULL;
 
         vartype = GLOBALS->facs[i]->n->vartype;
         if ((vartype < 0) || (vartype > GW_VAR_TYPE_MAX)) {

--- a/src/vcd.h
+++ b/src/vcd.h
@@ -33,6 +33,8 @@
 #include "debug.h"
 #include "tree.h"
 
+typedef struct _VcdFile VcdFile;
+
 #define VCD_SIZE_WARN (256) /* number of MB size where converter warning message appears */
 #define VCD_BSIZ 32768 /* size of getch() emulation buffer--this val should be ok */
 #define VCD_INDEXSIZ (8 * 1024 * 1024)
@@ -153,9 +155,9 @@ int strcpy_delimfix(char *too, char *from);
 void vcd_sortfacs(void);
 void set_vcd_vartype(struct vcdsymbol *v, GwNode *n);
 
-void vcd_import_masked(void);
-void vcd_set_fac_process_mask(GwNode *np);
-void import_vcd_trace(GwNode *np);
+void vcd_import_masked(VcdFile *self);
+void vcd_set_fac_process_mask(VcdFile *self, GwNode *np);
+void import_vcd_trace(VcdFile *self, GwNode *np);
 
 int vcd_keyword_code(const char *s, unsigned int len);
 #endif

--- a/src/vcd_partial.c
+++ b/src/vcd_partial.c
@@ -292,7 +292,7 @@ static void create_sorted_table(void)
     if (GLOBALS->numsyms_vcd_partial_c_2) {
         vcd_distance = GLOBALS->vcd_maxid_vcd_partial_c_2 - GLOBALS->vcd_minid_vcd_partial_c_2 + 1;
 
-        if ((vcd_distance <= VCD_INDEXSIZ) || (!GLOBALS->vcd_hash_kill)) {
+        if ((vcd_distance <= VCD_INDEXSIZ) || (!GLOBALS->vcd_hash_kill_partial)) {
             GLOBALS->indexed_vcd_partial_c_2 =
                 (struct vcdsymbol **)calloc_2(vcd_distance, sizeof(struct vcdsymbol *));
 
@@ -1394,12 +1394,12 @@ static void vcd_parse(void)
                         v->nid = vcdid_hash(GLOBALS->yytext_vcd_partial_c_2,
                                             GLOBALS->yylen_vcd_partial_c_2);
 
-                        if (v->nid == (GLOBALS->vcd_hash_max + 1)) {
-                            GLOBALS->vcd_hash_max = v->nid;
-                        } else if ((v->nid > 0) && (v->nid <= GLOBALS->vcd_hash_max)) {
+                        if (v->nid == (GLOBALS->vcd_hash_max_partial + 1)) {
+                            GLOBALS->vcd_hash_max_partial = v->nid;
+                        } else if ((v->nid > 0) && (v->nid <= GLOBALS->vcd_hash_max_partial)) {
                             /* general case with aliases */
                         } else {
-                            GLOBALS->vcd_hash_kill = 1;
+                            GLOBALS->vcd_hash_kill_partial = 1;
                         }
 
                         if (v->nid < GLOBALS->vcd_minid_vcd_partial_c_2)
@@ -1482,12 +1482,12 @@ static void vcd_parse(void)
                         v->nid = vcdid_hash(GLOBALS->yytext_vcd_partial_c_2,
                                             GLOBALS->yylen_vcd_partial_c_2);
 
-                        if (v->nid == (GLOBALS->vcd_hash_max + 1)) {
-                            GLOBALS->vcd_hash_max = v->nid;
-                        } else if ((v->nid > 0) && (v->nid <= GLOBALS->vcd_hash_max)) {
+                        if (v->nid == (GLOBALS->vcd_hash_max_partial + 1)) {
+                            GLOBALS->vcd_hash_max_partial = v->nid;
+                        } else if ((v->nid > 0) && (v->nid <= GLOBALS->vcd_hash_max_partial)) {
                             /* general case with aliases */
                         } else {
-                            GLOBALS->vcd_hash_kill = 1;
+                            GLOBALS->vcd_hash_kill_partial = 1;
                         }
 
                         if (v->nid < GLOBALS->vcd_minid_vcd_partial_c_2)
@@ -1842,7 +1842,7 @@ GwHistEnt *add_histent_p(GwTime tim, GwNode *n, char ch, int regadd, char *vecto
                     n->curr->next = he;
                     if (n->curr->v.h_val == heval) {
                         n->curr->flags |= GW_HIST_ENT_FLAG_GLITCH; /* set the glitch flag */
-                        GLOBALS->num_glitch_regions_vcd_recoder_c_4++;
+                        GLOBALS->num_glitch_regions_vcd_partial_c_3++;
                     }
                     n->curr = he;
                     GLOBALS->regions += regadd;

--- a/src/vcd_recoder.c
+++ b/src/vcd_recoder.c
@@ -91,6 +91,8 @@ typedef struct
     char *varsplit;
     char *vsplitcurr;
     int var_prevch;
+
+    gboolean already_backtracked;
 } VcdLoader;
 
 /**/
@@ -1817,8 +1819,8 @@ static void vcd_parse(VcdLoader *self)
                         } else {
                             /* backtracking fix */
                             if (tim < self->current_time) {
-                                if (!GLOBALS->vcd_already_backtracked) {
-                                    GLOBALS->vcd_already_backtracked = 1;
+                                if (!self->already_backtracked) {
+                                    self->already_backtracked = TRUE;
                                     fprintf(stderr,
                                             "VCDLOAD | Time backtracking detected in VCD file!\n");
                                 }


### PR DESCRIPTION
This PR moves the global variables that belong to the dump file loaders into structs in preparation for further refactoring and for moving the loaders into libgtkwave. Each loader uses two objects, one to store all variables that are only used during the initial loading and another that is kept for the runtime of the session. The second object contains all information that is necessary for the `import_XXX_trace` methods.