### PR TITLE
Set rpath for executables

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -200,6 +200,14 @@ foreach arg: test_warning_args
     endif
 endforeach
 
+# Set excutable rpaths for non standard prefixes
+
+if get_option('set_rpath').enabled() or (get_option('set_rpath').auto() and get_option('prefix') != '/usr')
+    install_rpath = get_option('prefix') / get_option('libdir')
+else
+    install_rpath = ''
+endif
+
 # config.h
 
 config.set_quoted('PACKAGE_BUGREPORT', 'bybell@rocketmail.com')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -67,3 +67,10 @@ option(
     value: true,
     description: 'Build tests',
 )
+
+option(
+    'set_rpath',
+    type: 'feature',
+    value: 'auto',
+    description: 'Set rpath for executables (automatically enabled if the prefix is not /usr)',
+)

--- a/src/helpers/meson.build
+++ b/src/helpers/meson.build
@@ -48,5 +48,6 @@ foreach helper : helpers
         c_args: warning_args,
         include_directories: config_inc,
         install: true,
+        install_rpath: install_rpath,
     )
 endforeach

--- a/src/meson.build
+++ b/src/meson.build
@@ -131,6 +131,7 @@ executable(
     c_args: warning_args,
     link_args: link_args,
     install: true,
+    install_rpath: install_rpath,
 )
 
 # twinwave
@@ -155,4 +156,5 @@ executable(
     dependencies: twinwave_dependencies,
     include_directories: twinwave_include_directories,
     install: true,
+    install_rpath: install_rpath,
 )


### PR DESCRIPTION
This PR changes the build system to set the rpath for executables if the prefix is not `/usr` or if the feature is enabled manually.