### PR TITLE
libghw - Update to latest upstream version, speedup

### DIFF
--- a/lib/libghw/libghw.c
+++ b/lib/libghw/libghw.c
@@ -655,7 +655,7 @@ ghw_read_type (struct ghw_handler *h)
       if (t == EOF)
 	return -1;
       if (h->flag_verbose > 1)
-	printf ("type[%d]= %d\n", i, t);
+	printf ("type[%u]= %d\n", i, t);
       switch (t)
 	{
 	case ghdl_rtik_type_b2:
@@ -684,6 +684,7 @@ ghw_read_type (struct ghw_handler *h)
 	    h->types[i] = (union ghw_type *) e;
 	    break;
 	  err_b2:
+	    free (e->lits);
 	    free (e);
 	    return -1;
 	  }
@@ -771,6 +772,7 @@ ghw_read_type (struct ghw_handler *h)
 	    h->types[i] = (union ghw_type *) arr;
 	    break;
 	  err_array:
+	    free (arr->dims);
 	    free (arr);
 	    return -1;
 	  }
@@ -1002,8 +1004,8 @@ ghw_read_signal (struct ghw_handler *h, unsigned int *sigs, union ghw_type *t)
 }
 
 int
-ghw_read_value (struct ghw_handler *h, union ghw_val *val,
-		union ghw_type *type)
+ghw_read_value (struct ghw_handler *h,
+		union ghw_val *val, union ghw_type *type)
 {
   switch (ghw_get_base_type (type)->kind)
     {
@@ -1079,7 +1081,7 @@ ghw_read_hie (struct ghw_handler *h)
   h->nbr_sigs = ghw_get_i32 (h, &hdr[12]);
 
   if (h->flag_verbose)
-    printf ("%u scopes, %u signals, %u signal elements\n", nbr_scopes,
+    printf ("%d scopes, %d signals, %u signal elements\n", nbr_scopes,
 	    nbr_sigs, h->nbr_sigs);
 
   blk = (struct ghw_hie *) malloc (sizeof (struct ghw_hie));
@@ -1095,6 +1097,7 @@ ghw_read_hie (struct ghw_handler *h)
   h->nbr_sigs++;
   h->skip_sigs = NULL;
   h->flag_full_names = 0;
+  h->sigs_no_null = 0;
   h->sigs = (struct ghw_sig *) malloc (h->nbr_sigs * sizeof (struct ghw_sig));
   memset (h->sigs, 0, h->nbr_sigs * sizeof (struct ghw_sig));
 
@@ -1210,10 +1213,20 @@ ghw_read_hie (struct ghw_handler *h)
 	}
     }
 
-  /* Allocate values.  */
+  /* Allocate values. Store indication if we have NULL-type signals with index
+     i > 0. Index i=0  */
+  int sigs_no_null = 1;
   for (i = 0; i < h->nbr_sigs; i++)
     if (h->sigs[i].type != NULL)
       h->sigs[i].val = (union ghw_val *) malloc (sizeof (union ghw_val));
+    else if (i > 0)
+      {
+	printf ("Warning: ghw_read_hie: NULL type signal %ud.", i);
+	printf ("Loading this file may take a long time.\n");
+	sigs_no_null = 0;
+      }
+
+  h->sigs_no_null = sigs_no_null;
   return 0;
 }
 
@@ -1503,7 +1516,7 @@ ghw_read_cycle_start (struct ghw_handler *h)
 int
 ghw_read_cycle_cont (struct ghw_handler *h, int *list)
 {
-  int i;
+  uint32_t i;
   int *list_p;
 
   i = 0;
@@ -1522,11 +1535,25 @@ ghw_read_cycle_cont (struct ghw_handler *h, int *list)
 	}
 
       /* Find next signal.  */
-      while (d > 0)
+      if (h->sigs_no_null)
 	{
-	  i++;
-	  if (h->sigs[i].type != NULL)
-	    d--;
+	  /* Fast version. */
+	  i = i + d;
+	  if (i >= h->nbr_sigs)
+	    goto err;
+	}
+      else
+	{
+	  /* Slow version: Linear search through all signals. Find d-th 
+	     element with non-NULL type. Note: Type of sigs[0] is ignored. */
+	  while (d > 0)
+	    {
+	      i++;
+	      if (i >= h->nbr_sigs)
+	        goto err;
+	      if (h->sigs[i].type != NULL)
+		d--;
+	    }
 	}
 
       if (ghw_read_signal_value (h, &h->sigs[i]) < 0)
@@ -1538,6 +1565,10 @@ ghw_read_cycle_cont (struct ghw_handler *h, int *list)
   if (list_p)
     *list_p = 0;
   return 0;
+
+err:
+  fprintf(stderr, "Error: ghw_read_cycle_cont: Invalid entry in GHW file.\n");
+  return -1;
 }
 
 int
@@ -2178,7 +2209,7 @@ ghw_disp_type (struct ghw_handler *h, union ghw_type *t)
 	    printf ("  %s = " GHWPRI64 " %s;\n", u->name, u->val,
 		    p->units[0].name);
 	  }
-	printf ("end units\n");
+	printf ("end units;\n");
       } break;
     case ghdl_rtik_type_array:
       {

--- a/lib/libghw/libghw.h
+++ b/lib/libghw/libghw.h
@@ -26,12 +26,17 @@
 #include "config.h"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* The libghw uses the standard c99 int32_t and int64_t.  They are declared
    in stdint.h.  Header inttypes.h includes stdint.h and provides macro for
    printf and co specifiers.  Use it if known to be available.  */
 
-#if defined(__cplusplus) ||                                                    \
-    (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)) ||            \
+#if defined(__cplusplus) ||                                                   \
+    defined(__linux__) ||                                                     \
+    (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)) ||           \
     defined(HAVE_INTTYPES_H)
 /* Use C99 standard header.  */
 #include <inttypes.h>
@@ -379,6 +384,8 @@ struct ghw_handler
   char *skip_sigs;
   int flag_full_names;
   struct ghw_sig *sigs;
+  /* 1: sigs does not contain any signals with type = NULL and index > 0 */
+  int sigs_no_null;
 
   /* Hierarchy.  */
   struct ghw_hie *hie;
@@ -468,4 +475,9 @@ void ghw_disp_range (union ghw_type *type, union ghw_range *rng);
 void ghw_disp_type (struct ghw_handler *h, union ghw_type *t);
 
 void ghw_disp_types (struct ghw_handler *h);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* _LIBGHW_H_ */


### PR DESCRIPTION
This updates libghw to the upstream from https://github.com/ghdl/ghdl. The main change is skipping a linear search in `ghw_read_cycle_cont`, if this is possible. In my testing this provided a massive speedup. With this change, loading the ghw file from https://github.com/gtkwave/gtkwave/issues/280#issuecomment-1791391127 took about 20s instead of more than 6 minutes before. The file consumes about 29 GB of RAM, and behaves quite strangely (e.g., signals change name after inserting them to the wave window). So there may still be some bugs left, but the results from the two implementations of `ghw_read_cycle_cont` matched (tested with an assert for a few different log files).

Includes the following changes:
 - https://github.com/ghdl/ghdl/pull/1825
 - https://github.com/ghdl/ghdl/pull/1807
 - https://github.com/ghdl/ghdl/pull/2585

Related to #280