### PR TITLE
Correctly handle the return value of shmat

### DIFF
--- a/contrib/rtlbrowse/stem_recurse.c
+++ b/contrib/rtlbrowse/stem_recurse.c
@@ -306,7 +306,7 @@ if(i==len)
 #else
 	anno_ctx = shmat(shmid, NULL, 0);
 #endif
-	if(anno_ctx)
+	if(anno_ctx != (void *) -1)
 		{
 		if((!memcmp(anno_ctx->matchword, WAVE_MATCHWORD, 4))&&(anno_ctx->aet_type > WAVE_ANNO_NONE)&&(anno_ctx->aet_type < WAVE_ANNO_MAX))
 			{

--- a/src/main.c
+++ b/src/main.c
@@ -2210,7 +2210,7 @@ savefile_bail:
 #else
         GLOBALS->dual_ctx = shmat(GLOBALS->dual_attach_id_main_c_1, NULL, 0);
 #endif
-        if (GLOBALS->dual_ctx) {
+        if (GLOBALS->dual_ctx != (void *) -1) {
             if (memcmp(GLOBALS->dual_ctx[GLOBALS->dual_id].matchword, DUAL_MATCHWORD, 4)) {
                 fprintf(stderr, "Not a valid shared memory ID for dual head operation, exiting.\n");
                 exit(255);
@@ -2605,9 +2605,11 @@ void activate_stems_reader(char *stems_name)
         if (shmid >= 0) {
             struct shmid_ds ds;
 
-            GLOBALS->anno_ctx = shmat(shmid, NULL, 0);
-            if (GLOBALS->anno_ctx) {
+            struct gtkwave_annotate_ipc_t *anno_ctx = shmat(shmid, NULL, 0);
+            if (anno_ctx != (void *) -1) {
                 pid_t pid;
+
+                GLOBALS->anno_ctx = anno_ctx;
 
                 memset(GLOBALS->anno_ctx, 0, sizeof(struct gtkwave_annotate_ipc_t));
 

--- a/src/twinwave.c
+++ b/src/twinwave.c
@@ -367,7 +367,7 @@ int main(int argc, char **argv)
         struct shmid_ds ds;
 
         dual_ctx = shmat(shmid, NULL, 0);
-        if (dual_ctx) {
+        if (dual_ctx != (void *) -1) {
             memset(dual_ctx, 0, 2 * sizeof(struct gtkwave_dual_ipc_t));
             memcpy(&dual_ctx[0].matchword, DUAL_MATCHWORD, 4);
             memcpy(&dual_ctx[1].matchword, DUAL_MATCHWORD, 4);


### PR DESCRIPTION
I was working on `rtlbrowse` and noticed the return value of shmat was being incorrectly handled
The current implementation cause seg fault with command  `rtlbrowse 0a123`  (or any hexadecimal digits that do not represent a valid shared memory ID)

According to POSIX 2008 and [man page](https://linux.die.net/man/2/shmat) of shmat
shmat will return (void *) -1 upon failure, not 0

I also corrected this issue for  other shmat in the code base.  
Although `MapViewOfFile` does return 0 upon failure. It already got its own error handler wrapped in `ifdef __MINGW32__` 