### PR TITLE
flatpak: add launchable tag in metainfo

### DIFF
--- a/share/io.github.gtkwave.GTKWave.metainfo.xml
+++ b/share/io.github.gtkwave.GTKWave.metainfo.xml
@@ -19,6 +19,8 @@
     </p>
   </description>
 
+  <launchable type="desktop-id">io.github.gtkwave.GTKWave.desktop</launchable>
+
   <url type="homepage">http://gtkwave.sourceforge.net/</url>
   <url type="bugtracker">https://github.com/gtkwave/gtkwave/issues</url>
   <url type="help">https://github.com/gtkwave/gtkwave</url>


### PR DESCRIPTION
According to the new [guidelines on flathub](https://docs.flathub.org/docs/for-app-authors/linter/#appstream-failed-validation),

> All graphical applications having a desktop file must have this tag in the MetaInfo.

Currently, all flatpak builds at https://github.com/flathub/io.github.gtkwave.GTKWave are failing due to this in the Validate Build step.