### PR TITLE
Redraw waveform highlight when trace selection changes

### DIFF
--- a/src/signal_list.c
+++ b/src/signal_list.c
@@ -1,4 +1,5 @@
 #include "signal_list.h"
+#include "gw-wave-view.h"
 #include "globals.h"
 #include "menu.h"
 
@@ -588,6 +589,10 @@ static gboolean button_release_event(GtkWidget *widget, GdkEventButton *event)
 
             signal_list->dirty = TRUE;
             gtk_widget_queue_draw(widget);
+
+            if (GLOBALS->highlight_wavewindow) {
+                gw_wave_view_force_redraw(GW_WAVE_VIEW(GLOBALS->wavearea));
+            }
         }
     }
 


### PR DESCRIPTION
Fixes an issue that was reported in #322, where the waveform highlight isn't updated correctly.