### PR TITLE
Fix memory leak in filter loads

### DIFF
--- a/src/ptranslate.c
+++ b/src/ptranslate.c
@@ -152,14 +152,13 @@ static void load_proc_filter(int which, char *name)
 
     result = fscanf(stream, "%s", abs_path);
 
-    if ((strlen(abs_path) == 0) || (!result)) {
-        status_text("Could not find filter process!\n");
-        pclose(stream); /* cppcheck */
-        return;
-    }
-
     pclose(stream);
     free_2(cmd);
+
+    if ((strlen(abs_path) == 0) || (!result)) {
+        status_text("Could not find filter process!\n");
+        return;
+    }
 #else
     strcpy(abs_path, exec_name);
 #endif

--- a/src/ttranslate.c
+++ b/src/ttranslate.c
@@ -170,14 +170,13 @@ static void load_ttrans_filter(int which, char *name)
 
     result = fscanf(stream, "%s", abs_path);
 
-    if ((strlen(abs_path) == 0) || (!result)) {
-        status_text("Could not find transaction filter process!\n");
-        pclose(stream); /* cppcheck */
-        return;
-    }
-
     pclose(stream);
     free_2(cmd);
+
+    if ((strlen(abs_path) == 0) || (!result)) {
+        status_text("Could not find transaction filter process!\n");
+        return;
+    }
 #else
     strcpy(abs_path, exec_name);
 #endif


### PR DESCRIPTION
 Previously, if the executable file was not found, the `cmd` pointer would not be properly released, leading to a memory leak.

`// I also recommend adding a popup notification when the executable file is not found. This would reduce confusion for users. However I'm not sure how to notifications get popped in gtkwave. 
`