### PR TITLE
Add GitHub Actions workflow 'docs'

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,35 @@
+name: 'docs'
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: pip install -r docs/requirements.txt
+
+    - name: Build docs
+      run: make -C docs html
+
+    - name: '🚀 Publish site'
+      if: github.event_name != 'pull_request' && github.ref_name == 'master'
+      run: |
+        cd docs/_build/html
+        touch .nojekyll
+        git init
+        cp ../../../.git/config ./.git/config
+
+        git add .
+        git config --local user.email "Pages@GitHubActions"
+        git config --local user.name "GitHub Actions"
+        git commit -a -m "update $GITHUB_SHA"
+
+        git push -u origin +HEAD:gh-pages

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,7 +6,7 @@
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
-BUILDDIR      = build
+BUILDDIR      = _build
 
 # Put it first so that "make" without argument is like "make help".
 help:


### PR DESCRIPTION
Ref: #144

This PR adds a GitHub Actions workflow to build and deploy the docs to GitHub Pages, so they can be browsed at gtkwave.gitlab.io/gtkwave. Some comments on the proposed solution:

- Dependencies are installed using the `requirements.txt` and docs are built using `make`, so it can be used as a reference for contributors to build the docs locally.

- The HTML is built only. However, it would be possible to build the PDF, man, ebook, outputs as well, if desired. Those would be made available as artifacts and/or pushed as assets of the nightly release: https://github.com/gtkwave/gtkwave/releases/tag/nightly; as done in e.g. https://github.com/ghdl/ghdl/releases/tag/nightly.

- The HTML output is pushed to branch `gh-pages` of the repo where the workflow is executed, as long as it's branch `master` and it's not a PR. In order to do so without dealing with tokens or other credentials, the proposed solution uses whichever credentials used by actions/checkout. The `.git` directory is copied, so that the same credentials used to clone the repo are used to create a new branch and push it.

  - Alternatively, repo `github.com/gtkwave/gtkwave.github.io` might be created and the content might be pushed to the root of that repo. Then, the URL would be gtkwave.github.io instead of gtkwave.github.io/gtkwave. However, that would require dealing with a token or SSH key, because the default credentials used by actions/checkout do not allow pushing to other repos in the org. See https://github.com/VUnit/vunit/blob/master/.github/publish_site.sh#L31-L37.
  
Note that GitHub Pages might need to be enabled. After this PR is merged and the content is pushed to branch `gh-pages`, go to the Settings of this repo, section Pages and enable using the root of branch `gh-pages`. Then, optionally, you can click on the cog at the right of section About in the sidebar of the repo https://github.com/gtkwave/gtkwave, and enable using Pages as the URL shown there.

---

Example result on my fork: https://umarcor.github.io/gtkwave/