### PR TITLE
Run 'apt-get update' in Linux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install dependencies
-        run: sudo apt-get -y install gperf desktop-file-utils libgtk-3-dev libjudy-dev libgirepository1.0-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install gperf desktop-file-utils libgtk-3-dev libjudy-dev libgirepository1.0-dev
       - name: Install meson
         run: pip install meson ninja
       - name: Setup meson build


### PR DESCRIPTION
This PR fixes the Linux CI build by running `apt-get update` before installing the dependencies.