### PR TITLE
Add GitHub Action workflow 'docs' using new recommended way 

### DIFF
--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -3,7 +3,7 @@ name: Build and deploy docs to GitHub Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-   branches: ["master"]
+    branches: ["master"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -1,0 +1,50 @@
+name: Build and deploy docs to GitHub Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+   branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: pip install -r docs/requirements.txt
+      - name: Build docs
+        run: make -C docs html
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "docs/build/html/"
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -8,11 +8,8 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+# Tighten permissions granted to the GITHUB_TOKEN
+permissions: {}
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -43,6 +40,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      pages: write
+      id-token: write    
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,7 @@ author = 'GTKWave Authors'
 extensions = [
     'myst_parser',
     'sphinx_design',
+    'sphinx.ext.githubpages'
 ]
 
 templates_path = ['_templates']


### PR DESCRIPTION
I noticed that the PR #338 hasn't been updated in a while.
This PR implements the same GitHub action as #338 but uses the new recommended way of publishing to GitHub Pages.
