### PR TITLE
Fix leading [LF] skipping issue

### DIFF
--- a/src/fgetdynamic.c
+++ b/src/fgetdynamic.c
@@ -22,7 +22,7 @@ char *fgetmalloc(FILE *handle)
         int ch = fgetc(handle);
         if (ch == EOF || ch == 0x00 || ch == '\n' || ch == '\r') {
             if (ch > 0 && line->len == 0) {
-                // skip leading CRs and LFs
+                continue; // skip leading CRs and LFs
             } else {
                 break;
             }


### PR DESCRIPTION
 When reading DOS format files. "AB[_CR_][_LF_]CD" should break to "AB" and "CD"  not  "AB" and "[_LF_]CD". 
The later one will mess up many function including `read_save_helper` .
`continue` must be added or leading [_LF_](or [_CR_]) will be incorrectly appended to the start of `line`