### PR TITLE
Fix Windows Build Issues

### DIFF
--- a/lib/libgtkwave/src/gw-fst-loader.c
+++ b/lib/libgtkwave/src/gw-fst-loader.c
@@ -753,7 +753,7 @@ static GwDumpFile *gw_fst_loader_load(GwLoader *loader, const char *fname, GErro
     self->subvar_jrb = make_jrb(); /* only used for attributes such as generated in VHDL, etc. */
     self->synclock_jrb = make_jrb(); /* only used for synthetic clocks */
 
-    uint numfacs = fstReaderGetVarCount(self->fst_reader);
+    uint64_t numfacs = fstReaderGetVarCount(self->fst_reader);
 
     GwFacs *facs = gw_facs_new(numfacs);
     self->mvlfacs = g_new0(GwFac, numfacs);
@@ -761,7 +761,7 @@ static GwDumpFile *gw_fst_loader_load(GwLoader *loader, const char *fname, GErro
     node_block = g_new0(GwNode, numfacs);
     self->mvlfacs_rvs_alias = g_new0(fstHandle, numfacs);
 
-    fprintf(stderr, FST_RDLOAD "Processing %d facs.\n", numfacs);
+    fprintf(stderr, FST_RDLOAD "Processing %lu facs.\n", numfacs);
     // TODO: update splash
     // /* SPLASH */ splash_sync(1, 5);
 

--- a/lib/libgtkwave/src/gw-fst-loader.c
+++ b/lib/libgtkwave/src/gw-fst-loader.c
@@ -753,7 +753,7 @@ static GwDumpFile *gw_fst_loader_load(GwLoader *loader, const char *fname, GErro
     self->subvar_jrb = make_jrb(); /* only used for attributes such as generated in VHDL, etc. */
     self->synclock_jrb = make_jrb(); /* only used for synthetic clocks */
 
-    uint64_t numfacs = fstReaderGetVarCount(self->fst_reader);
+    guint64 numfacs = fstReaderGetVarCount(self->fst_reader);
 
     GwFacs *facs = gw_facs_new(numfacs);
     self->mvlfacs = g_new0(GwFac, numfacs);

--- a/lib/libgtkwave/src/gw-vcd-loader.c
+++ b/lib/libgtkwave/src/gw-vcd-loader.c
@@ -6,6 +6,7 @@
 #include "vcd-keywords.h"
 #include <stdio.h>
 #include <fstapi.h>
+#include <errno.h>
 
 #define VCD_BSIZ 32768 /* size of getch() emulation buffer--this val should be ok */
 #define VCD_INDEXSIZ (8 * 1024 * 1024)

--- a/lib/liblxt/lxt2_read.h
+++ b/lib/liblxt/lxt2_read.h
@@ -35,13 +35,16 @@ extern "C" {
 
 #ifndef _MSC_VER
 #include <unistd.h>
-#ifdef HAVE_INTTYPES_H
-#include <inttypes.h>
-#endif
 #else
 typedef long off_t;
 #include <windows.h>
 #include <io.h>
+#endif
+
+#ifdef HAVE_INTTYPES_H
+#include <inttypes.h>
+#else
+#include <stdint.h>
 #endif
 
 #ifndef HAVE_FSEEKO
@@ -75,34 +78,22 @@ typedef long off_t;
 
 #define LXT2_RD_MAX_BLOCK_MEM_USAGE (64*1024*1024)	/* 64MB */
 
-#ifndef _MSC_VER
 typedef uint8_t 		lxtint8_t;
 typedef uint16_t 		lxtint16_t;
 typedef uint32_t		lxtint32_t;
 typedef uint64_t	 	lxtint64_t;
 typedef int32_t			lxtsint32_t;
 typedef int64_t			lxtsint64_t;
-#ifndef __MINGW32__
+
+#ifdef HAVE_INTTYPES_H
 #define LXT2_RD_LLD "%"PRId64
 #define LXT2_RD_LD "%"PRId32
 #else
-#define LXT2_RD_LLD "%I64d"
+#define LXT2_RD_LLD "%lld"
 #define LXT2_RD_LD "%d"
 #endif
 #define LXT2_RD_LLDESC(x) x##LL
 #define LXT2_RD_ULLDESC(x) x##ULL
-#else
-typedef unsigned __int8		lxtint8_t;
-typedef unsigned __int16	lxtint16_t;
-typedef unsigned __int32	lxtint32_t;
-typedef unsigned __int64	lxtint64_t;
-typedef          __int32	lxtsint32_t;
-typedef          __int64	lxtsint64_t;
-#define LXT2_RD_LLD "%I64d"
-#define LXT2_RD_LD "%d"
-#define LXT2_RD_LLDESC(x) x##i64
-#define LXT2_RD_ULLDESC(x) x##i64
-#endif
 
 #if LXT2_RD_GRANULE_SIZE > 32
 typedef lxtint64_t		granmsk_t;

--- a/lib/libvzt/vzt_read.h
+++ b/lib/libvzt/vzt_read.h
@@ -35,14 +35,18 @@ extern "C" {
 
 #ifndef _MSC_VER
 #include <unistd.h>
-#ifdef HAVE_INTTYPES_H
-#include <inttypes.h>
-#endif
 #else
 typedef long off_t;
 #include <windows.h>
 #include <io.h>
 #endif
+
+#ifdef HAVE_INTTYPES_H
+#include <inttypes.h>
+#else
+#include <stdint.h>
+#endif
+
 #ifndef HAVE_FSEEKO
 #define fseeko fseek
 #define ftello ftell
@@ -79,35 +83,22 @@ typedef int pthread_mutexattr_t;
 
 #define VZT_RD_MAX_BLOCK_MEM_USAGE (64*1024*1024)	/* 64MB */
 
-#ifndef _MSC_VER
 typedef uint8_t 		vztint8_t;
 typedef uint16_t 		vztint16_t;
 typedef uint32_t		vztint32_t;
 typedef uint64_t	 	vztint64_t;
 typedef int64_t			vztsint64_t;
 typedef int32_t			vztsint32_t;
-#ifndef __MINGW32__
+
+#ifdef HAVE_INTTYPES_H
 #define VZT_RD_LLD "%"PRId64
 #define VZT_RD_LD "%"PRId32
 #else
-#define VZT_RD_LLD "%I64d"
+#define VZT_RD_LLD "%lld"
 #define VZT_RD_LD "%d"
 #endif
 #define VZT_RD_LLDESC(x) x##LL
 #define VZT_RD_ULLDESC(x) x##ULL
-#else
-typedef unsigned __int8		vztint8_t;
-typedef unsigned __int16	vztint16_t;
-typedef unsigned __int32	vztint32_t;
-typedef unsigned __int64	vztint64_t;
-typedef          __int64	vztsint64_t;
-typedef          __int32	vztsint32_t;
-#define VZT_RD_LLD "%I64d"
-#define VZT_RD_LD "%d"
-#define VZT_RD_LLDESC(x) x##i64
-#define VZT_RD_ULLDESC(x) x##i64
-#endif
-
 
 #define VZT_RD_IS_GZ              (0)
 #define VZT_RD_IS_BZ2             (1)

--- a/src/file.c
+++ b/src/file.c
@@ -20,10 +20,6 @@
 #include <cocoa_misc.h>
 #endif
 
-#if defined __MINGW32__
-#include <windows.h>
-#endif
-
 #ifndef MAC_INTEGRATION
 static gboolean ffunc(const GtkFileFilterInfo *filter_info, gpointer data)
 {

--- a/src/globals.c
+++ b/src/globals.c
@@ -45,9 +45,6 @@
 #if !defined __MINGW32__
 #include <unistd.h>
 #include <sys/mman.h>
-#else
-#include <windows.h>
-#include <io.h>
 #endif
 
 struct Global *GLOBALS = NULL;

--- a/src/globals.h
+++ b/src/globals.h
@@ -18,6 +18,7 @@
 #if defined __MINGW32__
 #include <windows.h>
 #include <io.h>
+#undef interface
 #endif
 
 #define XXX_GDK_DRAWABLE(x) x

--- a/src/main.c
+++ b/src/main.c
@@ -194,9 +194,8 @@ static void close_all_fst_files(void) /* so mingw does delete of reader tempfile
 {
     unsigned int i;
     for (i = 0; i < GLOBALS->num_notebook_pages; i++) {
-        if ((*GLOBALS->contexts)[i]->fst_fst_c_1) {
-            fstReaderClose((*GLOBALS->contexts)[i]->fst_fst_c_1);
-            (*GLOBALS->contexts)[i]->fst_fst_c_1 = NULL;
+        if ((*GLOBALS->contexts)[i]->dump_file) {
+            g_clear_object(&((*GLOBALS->contexts)[i])->dump_file);
         }
     }
 }

--- a/src/tcl_np.c
+++ b/src/tcl_np.c
@@ -127,7 +127,7 @@ extern int NpLoadLibrary(HMODULE *tclHandle, char *dllName, int dllNameSize, cha
         /*
          * Try based on ActiveTcl registry entry
          */
-        char path[MAX_PATH], vers[MAX_PATH];
+        char vers[MAX_PATH];
         DWORD result, size = MAX_PATH;
         HKEY regKey;
 #define TCL_REG_DIR_KEY "Software\\ActiveState\\ActiveTcl"
@@ -200,7 +200,7 @@ extern int NpLoadLibrary(HMODULE *tclHandle, char *dllName, int dllNameSize, cha
                                     (char *)&msgPtr,
                                     0,
                                     NULL);
-            NpLog3("GetModuleFileNameA ERROR: %d (%s)\n",
+            NpLog3("GetModuleFileNameA ERROR: %lu (%s)\n",
                    code,
                    ((length == 0) ? "unknown error" : msgPtr));
             if (length > 0) {

--- a/src/tcl_np.c
+++ b/src/tcl_np.c
@@ -66,10 +66,8 @@ extern int NpLoadLibrary(HMODULE *tclHandle, char *dllName, int dllNameSize, cha
 {
     char *envdll, libname[MAX_PATH];
     HMODULE handle = (HMODULE)NULL;
-
     char path[MAX_PATH], *p;
-    /* #include <windows.h> */
-    /* #include <iostream> */
+
     if (!GetModuleFileName(NULL, path, MAX_PATH)) {
         printf("GetModuleFileName() failed\n");
     } else {


### PR DESCRIPTION
This PR fix several compiling errors on Windows ( both Cygwin and MSYS2)

Since MSVC supports %lld and int64_t starting from Visual Studio 2015, the use of __int64 in headers is no longer necessary.

Note: libglib in Cygwin is unmaintained and is not fully compatible with GCC version 11 or later.

