### PR TITLE
Fix undefined behaviour in fstMmap2 on 32-bit Windows

### DIFF
--- a/lib/libfst/fstapi.c
+++ b/lib/libfst/fstapi.c
@@ -347,8 +347,9 @@ return(NULL);
 
 static void *fstMmap2(size_t __len, int __fd, fst_off_t __off)
 {
+DWORD64 len64 = __len;  /* Must be 64-bit for shift below */
 HANDLE handle = CreateFileMapping((HANDLE)_get_osfhandle(__fd), NULL,
-				  PAGE_READWRITE, (DWORD)(__len >> 32),
+				  PAGE_READWRITE, (DWORD)(len64 >> 32),
 				  (DWORD)__len, NULL);
 if (!handle) { return NULL; }
 


### PR DESCRIPTION
This is a mistake introduced by my earlier PR #191. On 32-bit Windows `size_t` is a 32-bit type so shifting by 32 or more places is undefined behaviour. Avoid this by casting to `DWORD64` first.