### PR TITLE
Bump GLib dependency to 2.72

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,8 +25,8 @@ datadir_gtkwave = get_option('datadir') / 'gtkwave3'
 
 # Required dependency versions
 
-glib_req = '>=2.64.0'
-glib_req_macro = 'GLIB_VERSION_2_64'
+glib_req = '>=2.72.0'
+glib_req_macro = 'GLIB_VERSION_2_72'
 gtk_req = '>=3.24.0'
 gtk_mac_integration_req = '>=3.0.0'
 zlib_req = '>=1.2.0'


### PR DESCRIPTION
This PR bumps the GLib dependency to require at least version 2.72 to give access to some functions that were added between 2.64 and 2.72. This version of GLib the latest version that is available in Ubuntu 22.04 LTS, which is the first LTS version of Ubuntu which includes GTK 4. We might later tweak this requirement up or down a bit, depending on which minimum GTK 4 we want to support.