### PR TITLE
Fix: Failed to create rtlbrowse subprocess on windows

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2358,7 +2358,7 @@ void activate_stems_reader(char *stems_name)
 
                 update_time_box();
 
-                rc = CreateProcess("rtlbrowse.exe",
+                rc = CreateProcess(NULL,
                                    mylist,
                                    NULL,
                                    NULL,


### PR DESCRIPTION
In the CreateProcess function, the first parameter `lpApplicationName` does not use the search path, as documented in the [WINAPI Doc](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa#parameters).

The second parameter `lpCommandLine` uses the search path if `lpApplicationName` is NULL.

Tested on msys running on windows 11. 

However, due to Microsoft's removal of older documentation, I am uncertain whether this change might impact previous versions of Windows. Please let me know if I should setup such environment and test it.