### PR TITLE
Fix fstReaderOpen failure with Windows UCRT runtime library

### DIFF
--- a/lib/libfst/fstapi.c
+++ b/lib/libfst/fstapi.c
@@ -130,6 +130,7 @@ void **JenkinsIns(void *base_i, const unsigned char *mem, uint32_t length, uint3
 #define FST_HDR_TIMEZERO_SIZE           (8)
 #define FST_GZIO_LEN                    (32768)
 #define FST_HDR_FOURPACK_DUO_SIZE       (4*1024*1024)
+#define FST_ZWRAPPER_HDR_SIZE           (1+8+8)
 
 #if defined(__APPLE__) && defined(__MACH__)
 #define FST_MACOSX
@@ -4633,9 +4634,14 @@ if(sectype == FST_BL_ZWRAPPER)
                 }
 #endif
 
-        fstReaderFseeko(xc, xc->f, 1+8+8, SEEK_SET);
+        fstReaderFseeko(xc, xc->f, FST_ZWRAPPER_HDR_SIZE, SEEK_SET);
 #ifndef __MINGW32__
         fflush(xc->f);
+#else
+	/* Windows UCRT runtime library reads one byte ahead in the file
+	   even with buffering disabled and does not synchronise the
+	   file position after fseek. */
+	_lseek(fileno(xc->f), FST_ZWRAPPER_HDR_SIZE, SEEK_SET);
 #endif
 
         zfd = dup(fileno(xc->f));


### PR DESCRIPTION
This was reported by a couple of users in nickg/nvc#637. The `fstReaderOpen` function cannot open any FST files when linked against the Windows [Universal C Runtime](https://learn.microsoft.com/en-us/cpp/windows/universal-crt-deployment?view=msvc-170), the modern replacement for MSVC.

The problem is that the file position of the `zfd` file descriptor passed to `gzdopen` is 18 instead of the expected 17. I'm unsure if this is a bug or not but the behaviour can be seen easily with the following program:

```c
#include <stdio.h>
#include <fcntl.h>

#ifdef __MINGW32__
#include <io.h>
#else
#include <unistd.h>
int _tell(int fd)
{
   return lseek(fd, 0, SEEK_CUR);
}
#endif

int main(int argc, char **argv)
{
   FILE *f = fopen(argv[1], "rb");
   setvbuf(f, NULL, _IONBF, 0);
   char ch = fgetc(f);
   printf("ftell=%d _tell=%d\n", (int)ftell(f), _tell(fileno(f)));
   fseeko(f, 1, SEEK_SET);
   printf("ftell=%d _tell=%d\n", (int)ftell(f), _tell(fileno(f)));
   fflush(f);
   printf("ftell=%d _tell=%d\n", (int)ftell(f), _tell(fileno(f)));
   return 0;
}
```

With UCRT I get:

```
ftell=1 _tell=2
ftell=1 _tell=2
ftell=1 _tell=2
```

And traditional MSVCRT:

```
ftell=1 _tell=2
ftell=1 _tell=1
ftell=1 _tell=1
```

And Linux glibc for comparison:

```
ftell=1 _tell=1
ftell=1 _tell=1
ftell=1 _tell=1
```

On POSIX systems the `fflush` call guarantees to synchronise the file position in the C library with the underlying file descriptor, so on Windows we can get the same effect by doing an `_lseek` on the file handle directly.