### PR TITLE
Fix Ubuntu 24.04/clang 18.0 warning on chk_len

### DIFF
--- a/lib/libfst/fstapi.c
+++ b/lib/libfst/fstapi.c
@@ -550,8 +550,9 @@ return(rc);
 
 static uint32_t fstReaderVarint32(FILE *f)
 {
-int chk_len = 5; /* TALOS-2023-1783 */
-unsigned char buf[chk_len];
+const int chk_len_max = 5; /* TALOS-2023-1783 */
+int chk_len = chk_len_max;
+unsigned char buf[chk_len_max];
 unsigned char *mem = buf;
 uint32_t rc = 0;
 int ch;
@@ -582,8 +583,9 @@ return(rc);
 
 static uint32_t fstReaderVarint32WithSkip(FILE *f, uint32_t *skiplen)
 {
-int chk_len = 5; /* TALOS-2023-1783 */
-unsigned char buf[chk_len];
+const int chk_len_max = 5; /* TALOS-2023-1783 */
+int chk_len = chk_len_max;
+unsigned char buf[chk_len_max];
 unsigned char *mem = buf;
 uint32_t rc = 0;
 int ch;
@@ -615,8 +617,9 @@ return(rc);
 
 static uint64_t fstReaderVarint64(FILE *f)
 {
-int chk_len = 16; /* TALOS-2023-1783 */
-unsigned char buf[chk_len];
+const int chk_len_max = 16; /* TALOS-2023-1783 */
+int chk_len = chk_len_max;
+unsigned char buf[chk_len_max];
 unsigned char *mem = buf;
 uint64_t rc = 0;
 int ch;


### PR DESCRIPTION
This fixes Clang 18 (default clang version in Ubuntu 24.04) compiler errors.

```
gtkwave/fstapi.c:554:19: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
  554 | unsigned char buf[chk_len];
      |                   ^~~~~~~
gtkwave/fstapi.c:554:19: note: read of non-const variable 'chk_len' is not allowed in a constant expression
gtkwave/fstapi.c:553:5: note: declared here
  553 | int chk_len = 5; /* TALOS-2023-1783 */
      |     ^
```
