### PR TITLE
Fix duplicate 'releases' tags in metainfo

### DIFF
--- a/gtkwave3-gtk3/share/appdata/io.github.gtkwave.GTKWave.metainfo.xml
+++ b/gtkwave3-gtk3/share/appdata/io.github.gtkwave.GTKWave.metainfo.xml
@@ -45,7 +45,6 @@
       </description>
     </release>
 
-  <releases>
     <release version="3.3.120" date="2024-06-14">
       <description>
         <p>

--- a/gtkwave3/share/appdata/io.github.gtkwave.GTKWave.metainfo.xml
+++ b/gtkwave3/share/appdata/io.github.gtkwave.GTKWave.metainfo.xml
@@ -45,7 +45,6 @@
       </description>
     </release>
 
-  <releases>
     <release version="3.3.120" date="2024-06-14">
       <description>
         <p>


### PR DESCRIPTION
They cause metainfo validation to fail.

Looks like a copy-and-paste issue.