### PR TITLE
Add RISC-V target to CI flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,36 @@ jobs:
       - name: Run tests
         run: meson test -C build -v
 
+  build-linux-riscv:
+    name: Build (Linux-RV)
+    runs-on: ubuntu-latest
+    # Tighten permissions granted to the GITHUB_TOKEN
+    permissions:
+      packages: write # for uraimo/run-on-arch-action to cache docker images
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build
+        uses: uraimo/run-on-arch-action@v2
+        with:
+          arch: riscv64
+          distro: ubuntu_latest
+          # Not mandatory, but speeds up builds by storing container images
+          #with dependencies installed in a GitHub package registry.
+          githubToken: ${{ github.token }}
+
+          # Install some dependencies in the container
+          # sudo is not required
+          install: |
+            apt-get update
+            apt-get -y install gperf desktop-file-utils libgtk-3-dev libgtk-4-dev libjudy-dev libgirepository1.0-dev
+            apt-get -y install meson ninja-build flex
+
+          run: |
+            meson setup build
+            meson compile -C build
+            meson test -C build -v 
+
   build-macos:
     name: Build (macOS)
     runs-on: macos-14


### PR DESCRIPTION
This PR adds build and test steps in CI for RISC-V Linux using `uraimo/run-on-arch-action`.
While gtkwave itself is architecture-independent. Including tests on another architecture might aids packagers on other distros. Just in case there are any niche requirements / inconsistency specific to different platforms.
Apt is utilized instead of pip to install meson and ninja because the python base environments is externally managed in the building container.


Note: This PR does not produce a distributable package for RISC-V Linux. As stated in Meson [manual](https://mesonbuild.com/Creating-Linux-binaries.html), "app is guaranteed to break as different distros have binary-incompatible C++ libraries" ( unless statically linked )
