### PR TITLE
LTS: Fix building on macOS with gtk3

### DIFF
--- a/gtkwave3-gtk3/configure
+++ b/gtkwave3-gtk3/configure
@@ -7361,7 +7361,7 @@ $as_echo "yes" >&6; }
 fi
         GTK_VER=`$PKG_CONFIG gtk+-3.0 --modversion`
 
-        _gdk_tgt=`$PKG_CONFIG --variable=target gdk-3.0`
+        _gdk_tgt=`$PKG_CONFIG --variable=targets gdk-3.0`
         if test "x$_gdk_tgt" = xquartz; then
 
 pkg_failed=no

--- a/gtkwave3-gtk3/configure.ac
+++ b/gtkwave3-gtk3/configure.ac
@@ -610,7 +610,7 @@ if test "X$GTK3" = "Xyes" ; then
         PKG_CHECK_MODULES(GTK, gtk+-3.0 >= 3.0.0)
         GTK_VER=`$PKG_CONFIG gtk+-3.0 --modversion`
 
-        _gdk_tgt=`$PKG_CONFIG --variable=target gdk-3.0`
+        _gdk_tgt=`$PKG_CONFIG --variable=targets gdk-3.0`
         if test "x$_gdk_tgt" = xquartz; then
            PKG_CHECK_MODULES(GTK_MAC, gtk-mac-integration >= 3.0.0)
            AC_SUBST(GTK_MAC_LIBS)

--- a/gtkwave3-gtk3/src/main.c
+++ b/gtkwave3-gtk3/src/main.c
@@ -2080,10 +2080,15 @@ if(!GLOBALS->socket_xid)
 #ifdef WAVE_USE_XID
 	else
 	{
+#ifdef GDK_WINDOWING_X11
         GLOBALS->mainwindow = gtk_plug_new(GLOBALS->socket_xid);
         gtk_widget_show(GLOBALS->mainwindow);
 
         g_signal_connect(XXX_GTK_OBJECT(GLOBALS->mainwindow), "destroy",   /* formerly was "destroy" */G_CALLBACK(plug_destroy),"Plug destroy");
+#else
+        fprintf(stderr, "GTKWAVE | GtkPlug widget is unavailable\n");
+        exit(1);
+#endif
 	}
 #endif
 }

--- a/gtkwave3-gtk3/src/twinwave.c
+++ b/gtkwave3-gtk3/src/twinwave.c
@@ -143,6 +143,7 @@ if(GDK_IS_WAYLAND_DISPLAY(gdk_display_get_default()))
 	use_embedded = 0;
 	}
 #endif
+#if defined(__GTK_SOCKET_H__) && defined(GDK_WINDOWING_X11)
 	{
 	xsocket[0] = gtk_socket_new ();
 	xsocket[1] = gtk_socket_new ();
@@ -152,6 +153,7 @@ if(GDK_IS_WAYLAND_DISPLAY(gdk_display_get_default()))
 
 if(!twinwayland)
 g_signal_connect(XXX_GTK_OBJECT(xsocket[0]), "plug-removed", G_CALLBACK(plug_removed), NULL);
+#endif
 
 #if GTK_CHECK_VERSION(3,0,0)
 main_vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
@@ -171,12 +173,14 @@ vpan = gtk_vpaned_new ();
 gtk_widget_show (vpan);
 gtk_box_pack_start (GTK_BOX (main_vbox), vpan, TRUE, TRUE, 1);
 
+#if defined(__GTK_SOCKET_H__) && defined(GDK_WINDOWING_X11)
 if(!twinwayland)
 	{
 	gtk_paned_pack1 (GTK_PANED (vpan), xsocket[0], TRUE, FALSE);
 	g_signal_connect(XXX_GTK_OBJECT(xsocket[1]), "plug-removed", G_CALLBACK(plug_removed), NULL);
 	gtk_paned_pack2 (GTK_PANED (vpan), xsocket[1], TRUE, FALSE);
 	}
+#endif
 #endif
 
 #ifdef __MINGW32__
@@ -208,7 +212,7 @@ if(hMapFile != NULL)
 				memset(&pi, 0, sizeof(PROCESS_INFORMATION));
 
 				sprintf(buf, "0+%08X", shmid);
-#ifdef MINGW_USE_XID
+#if defined(MINGW_USE_XID) && defined(__GTK_SOCKET_H__) && defined(GDK_WINDOWING_X11)
 				sprintf(buf2, "%x", gtk_socket_get_id (GTK_SOCKET(xsocket[0])));
 #else
 				sprintf(buf2, "%x", 0);
@@ -279,7 +283,7 @@ if(hMapFile != NULL)
 				memset(&pi, 0, sizeof(PROCESS_INFORMATION));
 
 				sprintf(buf, "1+%08X", shmid);
-#ifdef MINGW_USE_XID
+#if defined(MINGW_USE_XID) && defined(__GTK_SOCKET_H__) && defined(GDK_WINDOWING_X11)
 				sprintf(buf2, "%x", gtk_socket_get_id (GTK_SOCKET(xsocket[1])));
 #else
 				sprintf(buf2, "%x", 0);
@@ -429,10 +433,12 @@ if(shmid >=0)
 				sprintf(buf, "0+%08X", shmid);
 				if(use_embedded)
 					{
+#if defined(__GTK_SOCKET_H__) && defined(GDK_WINDOWING_X11)
 #ifdef MAC_INTEGRATION
 					sprintf(buf2, "%x", gtk_socket_get_id (GTK_SOCKET(xsocket[0])));
 #else
 					sprintf(buf2, "%lx", (long)gtk_socket_get_id (GTK_SOCKET(xsocket[0])));
+#endif
 #endif
 					}
 					else
@@ -467,10 +473,12 @@ if(shmid >=0)
 			sprintf(buf, "1+%08X", shmid);
 			if(use_embedded)
 				{
+#if defined(__GTK_SOCKET_H__) && defined(GDK_WINDOWING_X11)
 #ifdef MAC_INTEGRATION
 				sprintf(buf2, "%x", gtk_socket_get_id (GTK_SOCKET(xsocket[1])));
 #else
 				sprintf(buf2, "%lx", (long)gtk_socket_get_id (GTK_SOCKET(xsocket[1])));
+#endif
 #endif
 				}
 				else


### PR DESCRIPTION
Currently, the lts version cannot be built on macOS if gtk3 is used.

GtkSocket and GtkPlug are not available on macOS.  I backported a change from master branch to fix it.

In addition, the configure script cannot detect the quartz target of gdk because the variable name of pkg-config is changed.
It should be `targets` rather than `target`.  This pull request also fixes that.
