### PR TITLE
fix stringop-overread warning

### DIFF
--- a/lib/libfst/CMakeLists.txt
+++ b/lib/libfst/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 
 project (fstlib)
 

--- a/lib/libfst/fstapi.c
+++ b/lib/libfst/fstapi.c
@@ -3907,16 +3907,18 @@ while (value)
 static int fstVcdIDForFwrite(char *buf, unsigned int value)
 {
 char *pnt = buf;
+ int len = 0;
 
 /* zero is illegal for a value...it is assumed they start at one */
-while (value)
+while (value && len <= 14)
         {
         value--;
+	++len;
         *(pnt++) = (char)('!' + value % 94);
         value = value / 94;
         }
 
-return(pnt - buf);
+return len;
 }
 
 


### PR DESCRIPTION
This pr contributes a few quality-of-life improvements that I have come across. It fixes a stringop-overread warning issued by the C compiler at build and sets the minimum cmake version to a non-deprecated version.

## Fix stringop-overread Warning

### Observation

When building `libfst` from the `lib` directory I use the following command:

    cmake --DCMAKE_C_FLAGS="-O3 -Wall -Wextra -pedantic" -Hlibfst -Blibfst
    cmake --build libfst --target all

This produces the following warning:

    In function ‘fstWritex’,
        inlined from ‘fstReaderIterBlocks2.part.0’ at /tmp/build-via-sdist-b4bq_3__/pylibfst-0.2.1.dev0/fst/fstapi.c:5903:41:
    /tmp/build-via-sdist-b4bq_3__/pylibfst-0.2.1.dev0/fst/fstapi.c:3468:21: warning: ‘write’ reading between 65536 and 2147483647 bytes from a region of size 16 [-Wstringop-overread]
     3468 |                 if (write(xc->writex_fd, s, len)) { };
          |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /tmp/build-via-sdist-b4bq_3__/pylibfst-0.2.1.dev0/fst/fstapi.c: In function ‘fstReaderIterBlocks2.part.0’:
    /tmp/build-via-sdist-b4bq_3__/pylibfst-0.2.1.dev0/fst/fstapi.c:5899:46: note: source object ‘vcd_id’ of size 16
     5899 |                                         char vcd_id[16];
          |                                              ^~~~~~
    In file included from /usr/include/zconf.h:492,
                     from /usr/include/zlib.h:34,
                     from /tmp/build-via-sdist-b4bq_3__/pylibfst-0.2.1.dev0/fst/fstapi.h:36,
                     from /tmp/build-via-sdist-b4bq_3__/pylibfst-0.2.1.dev0/fst/fstapi.c:45:
    /usr/include/unistd.h:378:16: note: in a call to function ‘write’ declared with attribute ‘access (read_only, 2, 3)’
      378 | extern ssize_t write (int __fd, const void *__buf, size_t __n) __wur
          |                ^~~~~

This is due to the function `fstVcdIDForFwrite` which produces id strings of unbounded size. This function is applied, however, to arrays whose size is only 16. Two bytes of such an array are reserved for delimiters. Thus, the maximum allowable size of an id string is 14.

### Execution

This pr explicitly limits the size of an id string to 14, thus removing the warning.

## Fix cmake minimum version

### Observation

When using contemporary distributions of `cmake` a warning is issued that versions before 3.10 are deprecated. I have been using cmake version 3.31.1 which ships with Alpine Linux 3.21.0.

### Execution

I have set the minimum version of cmake to 3.10.