### PR TITLE
fix left-shift and signedness warnings

### DIFF
--- a/lib/libfst/fstapi.c
+++ b/lib/libfst/fstapi.c
@@ -3910,7 +3910,7 @@ char *pnt = buf;
  int len = 0;
 
 /* zero is illegal for a value...it is assumed they start at one */
-while (value && len <= 14)
+while (value && len < 14)
         {
         value--;
 	++len;

--- a/lib/libghw/libghw.c
+++ b/lib/libghw/libghw.c
@@ -259,7 +259,6 @@ ghw_read_sleb128 (struct ghw_handler *h, int32_t * res)
 int
 ghw_read_lsleb128 (struct ghw_handler *h, int64_t * res)
 {
-  static const int64_t r_mask = -1;
   int64_t r = 0;
   unsigned int off = 0;
 
@@ -273,7 +272,7 @@ ghw_read_lsleb128 (struct ghw_handler *h, int64_t * res)
       if ((v & 0x80) == 0)
 	{
 	  if ((v & 0x40) && off < 64)
-	    r |= r_mask << off;
+	    r |= ~((1 << off)-1);
 	  break;
 	}
     }

--- a/lib/libghw/libghw.c
+++ b/lib/libghw/libghw.c
@@ -259,6 +259,7 @@ ghw_read_sleb128 (struct ghw_handler *h, int32_t * res)
 int
 ghw_read_lsleb128 (struct ghw_handler *h, int64_t * res)
 {
+  static const int64_t r_mask = -1;
   int64_t r = 0;
   unsigned int off = 0;
 
@@ -272,7 +273,7 @@ ghw_read_lsleb128 (struct ghw_handler *h, int64_t * res)
       if ((v & 0x80) == 0)
 	{
 	  if ((v & 0x40) && off < 64)
-	    r |= ~((1 << off)-1);
+	    r |= r_mask << off;
 	  break;
 	}
     }

--- a/lib/libgtkwave/src/gw-vcd-file.h
+++ b/lib/libgtkwave/src/gw-vcd-file.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <gtkwave.h>
+#include "gtkwave.h"
 
 G_BEGIN_DECLS
 

--- a/lib/libvzt/vzt_read.c
+++ b/lib/libvzt/vzt_read.c
@@ -171,12 +171,12 @@ return((m1<<24)|(m2<<16)|(m3<<8)|m4);
 }
 
 
-static vztint32_t vzt_rd_get_v32(unsigned char **mmx)
+static vztint32_t vzt_rd_get_v32(char **mmx)
 {
-unsigned char *c;
-unsigned char *beg;
+char *c;
+char *beg;
 vztint32_t val;
-unsigned char **mm = mmx;
+char **mm = mmx;
 
 c = *mm;
 beg = c;
@@ -202,12 +202,12 @@ if(!(*c & 0x80))
 return(val);
 }
 
-static vztint64_t vzt_rd_get_v64(unsigned char **mmx)
+static vztint64_t vzt_rd_get_v64(char **mmx)
 {
-unsigned char *c;
-unsigned char *beg;
+char *c;
+char *beg;
 vztint64_t val;
-unsigned char **mm = mmx;
+char **mm = mmx;
 
 c = *mm;
 beg = c;
@@ -314,7 +314,7 @@ vztint64_t *times=NULL;
 vztint32_t *change_dict=NULL;
 vztint32_t *val_dict=NULL;
 unsigned int num_time_ticks, num_sections, num_dict_entries;
-unsigned char *pnt = b->mem;
+char *pnt = b->mem;
 vztint32_t i, j, m, num_dict_words;
 /* vztint32_t *block_end = (vztint32_t *)(pnt + b->uncompressed_siz); */
 vztint32_t *val_tmp;


### PR DESCRIPTION
This pr fixes an issue where a negative number is left-shifted in ghw, an implicit cast from a signed to an unsigned data type in vzt and improves upon an earlier fix that introduced a limit in the size of an id string in fst.

## ghw: left-shift of negative number

The left-shift of a negative number causes a warning in ghw.

### Observation

Compiling gtkwave produces the following warning:

    ../lib/libghw/libghw.c:276:25: warning: left shift of negative value [-Wshift-negative-value]
      276 |             r |= r_mask << off;
          |                  ~~~~~~~^~~~~~


### Execution

The fix creates the mask not by shifting in zeros into a one-vector from the right but by shifting in ones into a zero-vector from the right and then negating.

## vzt: implicit cast from signed to unsigned

An implicit cast from a signed char pointer to an unsigned char pointer causes a warning in vzt.

### Observation

Compiling gtkwave produces the following warning:

    ../lib/libvzt/vzt_read.c:317:22: warning: pointer targets in initialization of ‘unsigned char *’ from ‘char *’ differ in signedness [-Wpointer-sign]
      317 | unsigned char *pnt = b->mem;
          |                      ^
    ../lib/libvzt/vzt_read.c:405:5: warning: pointer targets in assignment from ‘char *’ to ‘unsigned char *’ differ in signedness [-Wpointer-sign]
      405 | pnt = (char *)(val_dict + (num_dict_words = num_dict_entries * num_sections));
          |     ^
    ../lib/libvzt/vzt_read.c:434:5: warning: pointer targets in assignment from ‘char *’ to ‘unsigned char *’ differ in signedness [-Wpointer-sign]
      434 | pnt = (char *)(b->vindex + num_bitplanes * lt->total_values);
          |     ^
    ../lib/libvzt/vzt_read.c:442:30: warning: pointer targets in assignment from ‘unsigned char *’ to ‘char *’ differ in signedness [-Wpointer-sign]
      442 |                 b->sindex[i] = pnt;
          |                              ^
    ../lib/libvzt/vzt_read.c:443:32: warning: pointer targets in passing argument 1 of ‘strlen’ differ in signedness [-Wpointer-sign]
      443 |                 pnt += (strlen(pnt) + 1);
          |                                ^~~
          |                                |
          |                                unsigned char *


### Execution

I declared `pnt` to be signed. Not only mutes this the warning from the implicit cast when `pnt` is assigned from `b->mem` but also mutes the warnings when pnt is wrote back into `b->sindex` and when `pnt` is passed to `strlen`.

## fst: fix size limit of id string

An earlier fix that limited the size of an id string in fst (see #397) poorly enforces the required size limit of 14.

### Observation

Since the while loop might be entered, when the `len` variable is 14 initially, we end up with id strings of length up to 15.

### Execution

Enforce the `len` variable to be lower than 14 prior to entering the loop.

## gw-vcd-file.h: fix include

### Observation

`gw-vcd-file.h` includes `gtkwave.h`. Both files reside in the same directory. Therefore a quoted include is preferable.

### Execution

Make include quoted.