### PR TITLE
Fix building of libgtkwave docs

### DIFF
--- a/lib/libgtkwave/doc/meson.build
+++ b/lib/libgtkwave/doc/meson.build
@@ -1,3 +1,7 @@
+if not get_option('introspection')
+    error('building the libgtkwave docs requires gobject-introspection')
+endif
+
 gi_docgen = find_program('gi-docgen')
 
 libgtkwave_toml_conf = configuration_data()

--- a/lib/libgtkwave/src/meson.build
+++ b/lib/libgtkwave/src/meson.build
@@ -156,7 +156,7 @@ if get_option('introspection')
         libgtkwave_gir_includes += 'Peas-2'
     endif
 
-    libgtkwave_dep_sources += gnome.generate_gir(
+    libgtkwave_gir = gnome.generate_gir(
         libgtkwave,
         sources: libgtkwave_public_sources + libgtkwave_public_headers,
         namespace: 'Gw',
@@ -169,6 +169,8 @@ if get_option('introspection')
         header: 'gtkwave.h',
         install: true,
     )
+
+    libgtkwave_dep_sources += libgtkwave_gir[0]
 endif
 
 libgtkwave_dep = declare_dependency(


### PR DESCRIPTION
The changes in https://github.com/gtkwave/gtkwave/commit/254cf5c835ad4d638d51e4d76643a2329fb12ebc had broken the build of the libgtkwave docs.