### PR TITLE
Port to gcc 15

### DIFF
--- a/gtkwave3-gtk3/src/gtk23compat.h
+++ b/gtkwave3-gtk3/src/gtk23compat.h
@@ -52,7 +52,7 @@
 #define WAVE_GTK3_GESTURE_ZOOM_IS_1D
 #endif
 
-#define WAVE_GTKIFE(a,b,c,d,e) {a,b,c,d,e,NULL}
+#define WAVE_GTKIFE(a,b,c,d,e) {a,b,(void (*)(void))c,d,e,NULL}
 
 #if GTK_CHECK_VERSION(3,0,0)
 #define WAVE_GDK_GET_POINTER(a,b,c,bi,ci,d)  gdk_window_get_device_position(a, gdk_seat_get_pointer(gdk_display_get_default_seat(gdk_display_get_default())), bi, ci, d)

--- a/gtkwave3-gtk3/src/tcl_helper.h
+++ b/gtkwave3-gtk3/src/tcl_helper.h
@@ -29,7 +29,7 @@
 typedef struct
         {
         const char *cmdstr;
-        int (*func)();
+        int (*func)(void *, Tcl_Interp *, int, Tcl_Obj * const *);
         } tcl_cmdstruct;
 
 extern tcl_cmdstruct gtkwave_commands[];


### PR DESCRIPTION
gcc 15 strengthens the incompatible pointer type checks, particularly in respect of function pointers, where the types of arguments passed to the function are also now significant.

This change fixes one such case in `tcl_helper.h` and works around the other by using a typecast in `gtk23compat.h`, since the function argument types are not identical in all cases there.

I don't think this is likely to cause breakage with older compilers but the oldest I tried it with is gcc 9.3.1 and I didn't try any non-gcc compilers. I also didn't update the gtk2 codebase (would anybody be using a mix of that and gcc 15?).