### PR TITLE
fix(macOS): Replace deprecated APIs with modern equivalents

### DIFF
--- a/src/cocoa/alert_sheet.m
+++ b/src/cocoa/alert_sheet.m
@@ -69,7 +69,7 @@ modalCode = NSAlertThirdButtonReturn + (clickedButtonIndex - 2);
 }
 
 -(void) BE_beginSheetModalForWindow:(NSWindow *)aWindow {
-[self beginSheetModalForWindow:aWindow modalDelegate:nil didEndSelector:nil contextInfo:nil];
+[self beginSheetModalForWindow:aWindow completionHandler:nil];
 }
 
 @end

--- a/src/cocoa/cocoa_misc.c
+++ b/src/cocoa/cocoa_misc.c
@@ -21,7 +21,7 @@
 void gtk_open_external_file(const char *fpath)
 {
     NSString *nspath = [NSString stringWithUTF8String:fpath];
-    [[NSWorkspace sharedWorkspace] openFile:nspath];
+    [[NSWorkspace sharedWorkspace] openURL:[NSURL fileURLWithPath:nspath]];
 }
 
 /*************************/
@@ -58,9 +58,9 @@ static int gtk_simplereqbox_req_bridge_2(const char *title,
     }
 
     if (is_alert) {
-        [alert setAlertStyle:NSCriticalAlertStyle];
+        [alert setAlertStyle:NSAlertStyleCritical];
     } else {
-        [alert setAlertStyle:NSInformationalAlertStyle];
+        [alert setAlertStyle:NSAlertStyleInformational];
     }
 
     NSTextField *input = nil;


### PR DESCRIPTION
## Summary
This PR updates deprecated macOS Cocoa APIs to their modern equivalents, eliminating deprecation warnings when building on modern macOS versions.

## Changes

### `src/cocoa/cocoa_misc.c`
- **Line 24**: Replace `[[NSWorkspace sharedWorkspace] openFile:]` with `openURL:` (deprecated in macOS 11.0)
- **Line 61**: Replace `NSCriticalAlertStyle` with `NSAlertStyleCritical` (deprecated in macOS 10.12)
- **Line 63**: Replace `NSInformationalAlertStyle` with `NSAlertStyleInformational` (deprecated in macOS 10.12)

### `src/cocoa/alert_sheet.m`
- **Line 72**: Replace `beginSheetModalForWindow:modalDelegate:didEndSelector:contextInfo:` with `beginSheetModalForWindow:completionHandler:` (deprecated in macOS 10.10)

## Testing
- Built and tested on macOS Sequoia (arm64/Apple Silicon)
- Verified gtkwave launches and functions correctly
- No regressions observed

## Motivation
These deprecated APIs generate compiler warnings and may be removed in future macOS releases. Updating them ensures forward compatibility and cleaner builds.