### PR TITLE
Automatically turn fixed-point shift on when the shift is specified

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -4343,8 +4343,6 @@ void menu_dataformat_fpshift_specify(gpointer null_data, guint callback_action, 
              NULL,
              128,
              G_CALLBACK(menu_dataformat_fpshift_specify_cleanup));
-
-    dataformat(~(TR_FPDECSHIFT), 0);
 }
 
 void menu_dataformat_invert_on(gpointer null_data, guint callback_action, GtkWidget *widget)


### PR DESCRIPTION
There is code in `menu_dataformat_fpshift_specify_cleanup` that automatically turns fixed-point shift _on_, which is very useful behavior in my opinion.
I removed a line that automatically turns fixed-point shift _off_ again after this cleanup callback is run.

This has been bugging me for a while.