### PR TITLE
Remove .zip suffix from CI artifact name.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,8 @@ jobs:
       - name: Upload the archived GTKWave.app archive artifact
         uses: actions/upload-artifact@v4
         with:
-          name: gtkwave-macos-arm64-app.zip
+          # NOTE: Github adds a zip layer and appends '.zip' to the name.
+          name: gtkwave-macos-arm64-app
           path: build/GTKWave.app.zip
           if-no-files-found: error
           retention-days: 14


### PR DESCRIPTION
This eliminates the double suffix '.zip.zip' since Github adds its own zip layer.

No change in the artifact's content.