### PR TITLE
Add json-glib to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ macOS:
 ```sh
 brew install desktop-file-utils shared-mime-info       \
              gobject-introspection gtk-mac-integration \
-             meson ninja pkg-config gtk+3 gtk4
+             meson ninja pkg-config gtk+3 gtk4 json-glib
 ```
 
 ### Building GTKWave


### PR DESCRIPTION
json-glib flagged as a missing dependency during meson setup on mac, adding it to list of dependencies