### PR TITLE
Respect selected signals during recurse import

### DIFF
--- a/src/treesearch.c
+++ b/src/treesearch.c
@@ -1787,9 +1787,90 @@ top:
     }
 }
 
+struct recurse_selected_counter
+{
+    gint facilities;
+};
+
+static void recurse_count_selected(GtkTreeModel *model,
+                                   GtkTreePath *path,
+                                   GtkTreeIter *iter,
+                                   gpointer data)
+{
+    (void)path;
+
+    struct recurse_selected_counter *counter = data;
+    GwTreeNode *sel = NULL;
+
+    gtk_tree_model_get(model, iter, TREE_COLUMN, &sel, -1);
+    if (sel == NULL) {
+        return;
+    }
+
+    gint low = fetchlow(sel)->t_which;
+    gint high = fetchhigh(sel)->t_which;
+
+    if ((low < 0) || (high < low)) {
+        return;
+    }
+
+    counter->facilities += high - low + 1;
+}
+
+static enum sst_cb_action recurse_action_to_sst_action(guint callback_action)
+{
+    if (callback_action == WV_RECURSE_INSERT) {
+        return SST_ACTION_INSERT;
+    }
+
+    if (callback_action == WV_RECURSE_REPLACE) {
+        return SST_ACTION_REPLACE;
+    }
+
+    return SST_ACTION_APPEND;
+}
+
 void recurse_import(GtkWidget *widget, guint callback_action)
 {
+    gint fz = 0;
+
     if (GLOBALS->sst_sig_root_treesearch_gtk2_c_1 == NULL) {
+        return;
+    }
+
+    if ((GLOBALS->sig_selection_treesearch_gtk2_c_1 != NULL) &&
+        (gtk_tree_selection_count_selected_rows(GLOBALS->sig_selection_treesearch_gtk2_c_1) > 0)) {
+        struct recurse_selected_counter counter = {0};
+        gtk_tree_selection_selected_foreach(GLOBALS->sig_selection_treesearch_gtk2_c_1,
+                                            recurse_count_selected,
+                                            &counter);
+        fz = counter.facilities;
+        if (fz <= 0) {
+            return;
+        }
+
+        if (fz > WV_RECURSE_IMPORT_WARN) {
+            GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(GLOBALS->mainwindow),
+                                                       GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                       GTK_MESSAGE_WARNING,
+                                                       GTK_BUTTONS_YES_NO,
+                                                       "Really import %d facilit%s?",
+                                                       fz,
+                                                       (fz == 1) ? "y" : "ies");
+
+            gint response = gtk_dialog_run(GTK_DIALOG(dialog));
+            gtk_widget_destroy(dialog);
+
+            if (response != GTK_RESPONSE_YES) {
+                return;
+            }
+        }
+
+        widget = GLOBALS->mainwindow; /* otherwise using widget passed from the menu item
+                                         crashes on OSX */
+        set_window_busy(widget);
+        action_callback(recurse_action_to_sst_action(callback_action));
+        set_window_idle(widget);
         return;
     }
 
@@ -1802,7 +1883,7 @@ void recurse_import(GtkWidget *widget, guint callback_action)
     if (low < 0 || high < 0) {
         return;
     }
-    int fz = high - low + 1;
+    fz = high - low + 1;
 
     if (fz > WV_RECURSE_IMPORT_WARN) {
         char recwarn[128];

--- a/src/treesearch.c
+++ b/src/treesearch.c
@@ -1123,7 +1123,37 @@ static gboolean view_selection_func(GtkTreeSelection *selection,
 
 static gint button_press_event_std(GtkWidget *widget, GdkEventButton *event)
 {
-    (void)widget;
+    GtkTreePath *path = NULL;
+
+    if ((event->button == 3) && (event->type == GDK_BUTTON_PRESS)) {
+        GtkTreeView *view = GTK_TREE_VIEW(widget);
+        GtkTreeSelection *selection = gtk_tree_view_get_selection(view);
+
+        if (gtk_tree_view_get_path_at_pos(view,
+                                          (gint)event->x,
+                                          (gint)event->y,
+                                          &path,
+                                          NULL,
+                                          NULL,
+                                          NULL)) {
+            if (gtk_tree_selection_path_is_selected(selection, path)) {
+                gtk_tree_path_free(path);
+                do_sst_popup_menu(widget, event);
+                return TRUE;
+            }
+
+            gtk_tree_selection_unselect_all(selection);
+            gtk_tree_selection_select_path(selection, path);
+            gtk_tree_path_free(path);
+            do_sst_popup_menu(widget, event);
+            return TRUE;
+        }
+
+        if (gtk_tree_selection_count_selected_rows(selection) > 0) {
+            do_sst_popup_menu(widget, event);
+            return TRUE;
+        }
+    }
 
     if (event->type == GDK_2BUTTON_PRESS) {
         if (GLOBALS->selected_hierarchy_name && GLOBALS->selected_sig_name) {


### PR DESCRIPTION
This fixes two related issues in the SST signal-selection flow.

What changed:
- Recurse Import now respects the selected rows in the lower signal list when a signal selection exists.
- Right-clicking in the lower signal list no longer destroys an existing multi-selection before opening the SST popup menu.

Previous behavior:
- Recurse Import ignored the lower-pane selection and imported the entire selected scope.
- Right-clicking after selecting multiple signals collapsed the selection before the import action ran.

New behavior:
- If one or more rows are selected in the lower signal list, Recurse Import operates on those selected rows only.
- If no lower-pane selection exists, Recurse Import keeps the existing scope-wide behavior.
- Right-click on an already selected row preserves the current selection and opens the popup.
- Right-click on an unselected row selects that row and opens the popup.
- Right-click on empty space preserves the existing selection and opens the popup when a selection exists.

Files changed:
- `src/treesearch.c`

Notes:
- This was motivated by interactive SST usage where users select a subset of signals in the lower pane, then use the context menu to import only that subset.
